### PR TITLE
feat(data): add getIncompleteTasks() to TaskDao (closes #136)

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/data/local/TaskDao.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/data/local/TaskDao.kt
@@ -12,6 +12,9 @@ interface TaskDao {
     @Query("SELECT * FROM tasks ORDER BY created_at DESC")
     fun getAllTasks(): Flow<List<TaskEntity>>
 
+    @Query("SELECT * FROM tasks WHERE is_completed = 0 ORDER BY created_at DESC")
+    fun getIncompleteTasks(): Flow<List<TaskEntity>>
+
     @Query("SELECT * FROM tasks WHERE id = :id")
     suspend fun getTaskById(id: Long): TaskEntity?
 

--- a/docs/rpi/create-taskdao-interface.md
+++ b/docs/rpi/create-taskdao-interface.md
@@ -1,0 +1,29 @@
+# create-taskdao-interface
+
+**Implemented**: 2026-02-22
+**Complexity**: simple
+
+## What Changed
+
+- Added `getIncompleteTasks()` method to `TaskDao` interface
+- New Room `@Query` returns only tasks where `is_completed = 0`, ordered by `created_at DESC`
+
+## Why
+
+The existing `TaskDao` had no way to query only incomplete tasks at the database level. `GetRandomTaskUseCase` was filtering incomplete tasks in-memory after fetching all tasks. This DAO-level query enables efficient filtering directly in SQLite, and prepares the data layer for UI screens that display only actionable tasks.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/data/local/TaskDao.kt` - Added `getIncompleteTasks()` with `@Query` annotation
+
+## Implementation Notes
+
+- Followed the exact pattern of `getAllTasks()`: same return type (`Flow<List<TaskEntity>>`), same ordering (`created_at DESC`)
+- Used `WHERE is_completed = 0` matching SQLite's integer-boolean convention and the `@ColumnInfo` name from `TaskEntity`
+- Single-method addition; no other files modified
+
+## Verification
+
+- [x] Build: `./gradlew assembleDebug` passed (Room KSP validates SQL at compile time)
+- [x] Tests: `./gradlew test` passed with no regressions
+- [x] Manual: Confirmed method name, return type, and SQL filter match issue requirements


### PR DESCRIPTION
## Summary

- Adds `getIncompleteTasks()` method to `TaskDao` interface with `@Query("SELECT * FROM tasks WHERE is_completed = 0 ORDER BY created_at DESC")` annotation
- Returns `Flow<List<TaskEntity>>` for reactive observation of incomplete tasks
- Completes all 6 acceptance criteria from Issue #136

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL (Room KSP validates SQL at compile time)
- [x] `./gradlew test` — BUILD SUCCESSFUL, no regressions
- [x] `./gradlew lint` — BUILD SUCCESSFUL, no new lint issues
- [x] Method name, return type, and SQL filter verified against issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)