### PR TITLE
docs(domain): add KDoc to Task domain model

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/domain/model/Task.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/model/Task.kt
@@ -1,5 +1,15 @@
 package com.nshaddox.randomtask.domain.model
 
+/**
+ * Domain model representing a task.
+ *
+ * @property id Unique identifier for the task. Defaults to 0 for new tasks.
+ * @property title Short name or summary of the task.
+ * @property description Optional longer description of the task. Null when not provided.
+ * @property isCompleted Whether the task has been marked as done.
+ * @property createdAt Epoch milliseconds when the task was created.
+ * @property updatedAt Epoch milliseconds when the task was last modified.
+ */
 data class Task(
     val id: Long = 0,
     val title: String,

--- a/docs/rpi/create-task-domain-model.md
+++ b/docs/rpi/create-task-domain-model.md
@@ -1,0 +1,30 @@
+# create-task-domain-model
+
+**Implemented**: 2026-02-22
+**Complexity**: simple (from research phase)
+
+## What Changed
+
+- Added KDoc documentation to `Task.kt` domain model with `@property` tags for all fields
+- Documented epoch-millisecond timestamp convention matching `TaskEntity.kt` style
+
+## Why
+
+Issue #120 requested a well-documented domain-layer Task model. The data class already had the correct fields, but lacked documentation. Adding KDoc with `@property` tags brings the domain model in line with the `TaskEntity.kt` documentation standard, making the codebase more consistent and maintainable.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/domain/model/Task.kt` - Added class-level KDoc and `@property` tags for id, title, description, isCompleted, createdAt, updatedAt
+
+## Implementation Notes
+
+- Followed `TaskEntity.kt` KDoc pattern: class-level doc with `@property` tags
+- Kept `Long` timestamps (epoch millis) to avoid cascading changes from `Instant` migration
+- Instant timestamp migration deferred as a follow-up issue (requires core library desugaring, mapper updates, use case updates, and test updates)
+- Documentation-only change; no structural or behavioral modifications
+
+## Verification
+
+- [x] Tests: `./gradlew test` passed with no regressions
+- [x] Quality: `./gradlew assembleDebug` compiled successfully
+- [x] Manual: KDoc content reviewed, matches TaskEntity style


### PR DESCRIPTION
## Summary

- Adds KDoc documentation block to `Task.kt` domain model matching the existing `TaskEntity.kt` style
- Includes class-level description and `@property` tags for all 6 fields (`id`, `title`, `description`, `isCompleted`, `createdAt`, `updatedAt`)
- Timestamps documented as epoch milliseconds; `Instant` migration deferred as a separate follow-up issue

Closes #120

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all unit tests pass
- [x] `./gradlew lint` — no lint violations
- [ ] Review KDoc renders correctly in IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)