### PR TITLE
docs: add wire-taskdao-into-appdatabase implementation summary

### DIFF
--- a/docs/rpi/wire-taskdao-into-appdatabase.md
+++ b/docs/rpi/wire-taskdao-into-appdatabase.md
@@ -1,0 +1,32 @@
+# wire-taskdao-into-appdatabase
+
+**Implemented**: 2026-02-22
+**Complexity**: simple
+
+## What Changed
+
+- Verified `AppDatabase` correctly declares `abstract fun taskDao(): TaskDao` with Room annotations
+- Verified `DatabaseModule` provides `TaskDao` via Hilt with `@Singleton` scope
+- Confirmed Room KSP code generation produces `TaskDao_Impl` at compile time
+
+## Why
+
+Issue #142 required wiring `TaskDao` into `AppDatabase` so Room generates the DAO implementation and Hilt can inject it into repositories. The wiring was already implemented during prior database foundation work (#87) and DAO interface work (#136), so this issue focused on formal verification against acceptance criteria.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/data/local/AppDatabase.kt` - Declares `taskDao()` abstract function; `@Database` annotation registers `TaskEntity`
+- `app/src/main/java/com/nshaddox/randomtask/di/DatabaseModule.kt` - `provideTaskDao()` delegates to `db.taskDao()` with `@Provides @Singleton`
+
+## Implementation Notes
+
+- No new code was written; all wiring existed from prior PRs
+- KSP (not kapt) is used for Room annotation processing per project convention
+- `@Singleton` scope on both `AppDatabase` and `TaskDao` ensures single instance across app lifecycle
+- This unblocks Group 5 work: repository implementation (#150) and repository Hilt module (#151)
+
+## Verification
+
+- [x] Tests: `./gradlew test` -- BUILD SUCCESSFUL, 0 failures
+- [x] Quality: `./gradlew kspDebugKotlin` and `./gradlew assembleDebug` -- BUILD SUCCESSFUL
+- [x] Manual: `AppDatabase.kt` and `DatabaseModule.kt` inspected against all acceptance criteria


### PR DESCRIPTION
## Summary

- Adds RPI recap summary for issue #142 (Wire TaskDao into AppDatabase)
- No code changes — wiring was already fully implemented in prior PRs (#87, #136)
- All acceptance criteria verified: `@Database` annotation, `taskDao()` abstract function, `provideTaskDao()` Hilt binding, and passing builds

## Test plan

- [x] `./gradlew kspDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL, 0 failures

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)