### PR TITLE
docs: add create-data-domain-mappers implementation summary

### DIFF
--- a/docs/rpi/create-data-domain-mappers.md
+++ b/docs/rpi/create-data-domain-mappers.md
@@ -1,0 +1,32 @@
+# create-data-domain-mappers
+
+**Implemented**: 2026-02-22
+**Complexity**: simple (from research phase)
+
+## What Changed
+
+- Validated existing `TaskEntity.toDomain()` and `Task.toEntity()` extension functions
+- Confirmed all 5 unit tests cover field mapping, round-trip integrity, and null description
+- Verified mappers are integrated into all `TaskRepositoryImpl` CRUD operations
+
+## Why
+
+Issue #127 required extension functions to map between the Room data layer (`TaskEntity`) and the domain layer (`Task`). These mappers were already implemented during prior RPI cycles (`implement-task-domain-model` and `create-task-entity-for-room`). This cycle validated the existing implementation against acceptance criteria and confirmed closure readiness.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/data/repository/TaskMappers.kt` - Extension functions for bidirectional mapping (22 lines)
+- `app/src/test/java/com/nshaddox/randomtask/data/repository/TaskMappersTest.kt` - 5 unit tests covering all acceptance criteria
+- `app/src/main/java/com/nshaddox/randomtask/data/repository/TaskRepositoryImpl.kt` - Uses mappers in getTasks, getTaskById, addTask, updateTask
+
+## Implementation Notes
+
+- Mappers live in `data.repository` package as Kotlin extension functions (established project pattern)
+- Both models use `Long` (epoch millis) for timestamps; Instant/LocalDateTime migration deferred to a separate issue
+- No new production code was written; this RPI cycle was validation-only
+
+## Verification
+
+- [x] Tests: `./gradlew testDebugUnitTest` -- 5/5 mapper tests pass, full suite passes
+- [x] Quality: `./gradlew clean testDebugUnitTest assembleDebug` -- BUILD SUCCESSFUL
+- [x] Manual: All 6 fields mapped in both directions, round-trip integrity confirmed


### PR DESCRIPTION
## Summary

- Adds RPI recap document for issue #127 (Create data-domain mappers)
- Confirms all acceptance criteria already met: `TaskEntity.toDomain()` and `Task.toEntity()` exist in `data/repository/TaskMappers.kt`, 5 unit tests pass, and repository integration is complete
- No production code changes — this was a validation-only RPI cycle

Closes #127

## Test plan
- [x] All existing mapper unit tests pass (5/5)
- [x] Full test suite passes: `./gradlew clean testDebugUnitTest assembleDebug`
- [x] Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)