### PR TITLE
feat(domain): define TaskRepository interface per spec (closes #149)

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/data/local/TaskDao.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/data/local/TaskDao.kt
@@ -18,6 +18,9 @@ interface TaskDao {
     @Query("SELECT * FROM tasks WHERE id = :id")
     suspend fun getTaskById(id: Long): TaskEntity?
 
+    @Query("SELECT * FROM tasks WHERE id = :id")
+    fun getTaskByIdFlow(id: Long): Flow<TaskEntity?>
+
     @Insert
     suspend fun insertTask(task: TaskEntity): Long
 

--- a/app/src/main/java/com/nshaddox/randomtask/data/repository/TaskRepositoryImpl.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/data/repository/TaskRepositoryImpl.kt
@@ -11,14 +11,20 @@ class TaskRepositoryImpl @Inject constructor(
     private val taskDao: TaskDao
 ) : TaskRepository {
 
-    override fun getTasks(): Flow<List<Task>> {
+    override fun getAllTasks(): Flow<List<Task>> {
         return taskDao.getAllTasks().map { entities ->
             entities.map { it.toDomain() }
         }
     }
 
-    override suspend fun getTaskById(id: Long): Task? {
-        return taskDao.getTaskById(id)?.toDomain()
+    override fun getIncompleteTasks(): Flow<List<Task>> {
+        return taskDao.getIncompleteTasks().map { entities ->
+            entities.map { it.toDomain() }
+        }
+    }
+
+    override fun getTaskById(id: Long): Flow<Task?> {
+        return taskDao.getTaskByIdFlow(id).map { it?.toDomain() }
     }
 
     override suspend fun addTask(task: Task): Result<Long> {
@@ -39,9 +45,9 @@ class TaskRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteTask(taskId: Long): Result<Unit> {
+    override suspend fun deleteTask(task: Task): Result<Unit> {
         return try {
-            taskDao.deleteTaskById(taskId)
+            taskDao.deleteTaskById(task.id)
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/nshaddox/randomtask/domain/repository/TaskRepository.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/repository/TaskRepository.kt
@@ -3,10 +3,57 @@ package com.nshaddox.randomtask.domain.repository
 import com.nshaddox.randomtask.domain.model.Task
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Repository interface for managing [Task] persistence.
+ *
+ * Provides methods to observe, retrieve, create, update, and delete tasks.
+ * Implementations may use any backing store (e.g., Room, network, in-memory).
+ */
 interface TaskRepository {
-    fun getTasks(): Flow<List<Task>>
-    suspend fun getTaskById(id: Long): Task?
+
+    /**
+     * Observes all tasks, ordered by creation date descending.
+     *
+     * @return a [Flow] emitting the full list of tasks whenever the data changes.
+     */
+    fun getAllTasks(): Flow<List<Task>>
+
+    /**
+     * Observes only incomplete tasks, ordered by creation date descending.
+     *
+     * @return a [Flow] emitting incomplete tasks whenever the data changes.
+     */
+    fun getIncompleteTasks(): Flow<List<Task>>
+
+    /**
+     * Observes a single task by its unique identifier.
+     *
+     * @param id the unique identifier of the task.
+     * @return a [Flow] emitting the task if found, or null if no task matches the id.
+     */
+    fun getTaskById(id: Long): Flow<Task?>
+
+    /**
+     * Adds a new task to the repository.
+     *
+     * @param task the task to add. The [Task.id] field is ignored; a new id is generated.
+     * @return a [Result] containing the generated id on success, or an exception on failure.
+     */
     suspend fun addTask(task: Task): Result<Long>
+
+    /**
+     * Updates an existing task in the repository.
+     *
+     * @param task the task with updated fields. The [Task.id] must match an existing task.
+     * @return a [Result] containing [Unit] on success, or an exception on failure.
+     */
     suspend fun updateTask(task: Task): Result<Unit>
-    suspend fun deleteTask(taskId: Long): Result<Unit>
+
+    /**
+     * Deletes a task from the repository.
+     *
+     * @param task the task to delete. The [Task.id] is used to identify the record to remove.
+     * @return a [Result] containing [Unit] on success, or an exception on failure.
+     */
+    suspend fun deleteTask(task: Task): Result<Unit>
 }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/DeleteTaskUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/DeleteTaskUseCase.kt
@@ -1,12 +1,13 @@
 package com.nshaddox.randomtask.domain.usecase
 
+import com.nshaddox.randomtask.domain.model.Task
 import com.nshaddox.randomtask.domain.repository.TaskRepository
 import javax.inject.Inject
 
 class DeleteTaskUseCase @Inject constructor(
     private val repository: TaskRepository
 ) {
-    suspend operator fun invoke(taskId: Long): Result<Unit> {
-        return repository.deleteTask(taskId)
+    suspend operator fun invoke(task: Task): Result<Unit> {
+        return repository.deleteTask(task)
     }
 }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetRandomTaskUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetRandomTaskUseCase.kt
@@ -9,8 +9,7 @@ class GetRandomTaskUseCase @Inject constructor(
     private val repository: TaskRepository
 ) {
     suspend operator fun invoke(): Task? {
-        val tasks = repository.getTasks().first()
-        val incompleteTasks = tasks.filter { !it.isCompleted }
+        val incompleteTasks = repository.getIncompleteTasks().first()
         return if (incompleteTasks.isEmpty()) null else incompleteTasks.random()
     }
 }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksUseCase.kt
@@ -9,6 +9,6 @@ class GetTasksUseCase @Inject constructor(
     private val repository: TaskRepository
 ) {
     operator fun invoke(): Flow<List<Task>> {
-        return repository.getTasks()
+        return repository.getAllTasks()
     }
 }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/CompleteTaskUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/CompleteTaskUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.nshaddox.randomtask.domain.usecase
 
 import com.nshaddox.randomtask.domain.model.Task
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -21,23 +22,23 @@ class CompleteTaskUseCaseTest {
     @Test
     fun `invoke marks task as completed`() = runTest {
         repository.addTask(Task(title = "Incomplete", isCompleted = false, createdAt = 1000L, updatedAt = 1000L))
-        val task = repository.getTaskById(1L)!!
+        val task = repository.getTaskById(1L).first()!!
 
         val result = completeTaskUseCase(task)
 
         assertTrue(result.isSuccess)
-        val stored = repository.getTaskById(task.id)
+        val stored = repository.getTaskById(task.id).first()
         assertEquals(true, stored?.isCompleted)
     }
 
     @Test
     fun `invoke updates updatedAt timestamp`() = runTest {
         repository.addTask(Task(title = "Incomplete", isCompleted = false, createdAt = 1000L, updatedAt = 1000L))
-        val task = repository.getTaskById(1L)!!
+        val task = repository.getTaskById(1L).first()!!
 
         completeTaskUseCase(task)
 
-        val stored = repository.getTaskById(task.id)
+        val stored = repository.getTaskById(task.id).first()
         assertTrue(stored!!.updatedAt >= task.updatedAt)
     }
 }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/DeleteTaskUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/DeleteTaskUseCaseTest.kt
@@ -22,18 +22,19 @@ class DeleteTaskUseCaseTest {
     @Test
     fun `invoke deletes existing task successfully`() = runTest {
         repository.addTask(Task(title = "To Delete", createdAt = 1000L, updatedAt = 1000L))
-        val tasks = repository.getTasks().first()
-        val taskId = tasks.first().id
+        val tasks = repository.getAllTasks().first()
+        val task = tasks.first()
 
-        val result = deleteTaskUseCase(taskId)
+        val result = deleteTaskUseCase(task)
 
         assertTrue(result.isSuccess)
-        assertEquals(0, repository.getTasks().first().size)
+        assertEquals(0, repository.getAllTasks().first().size)
     }
 
     @Test
-    fun `invoke with non-existent id returns failure`() = runTest {
-        val result = deleteTaskUseCase(999L)
+    fun `invoke with non-existent task returns failure`() = runTest {
+        val nonExistentTask = Task(id = 999L, title = "Ghost", createdAt = 1000L, updatedAt = 1000L)
+        val result = deleteTaskUseCase(nonExistentTask)
 
         assertTrue(result.isFailure)
     }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/FakeTaskRepository.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/FakeTaskRepository.kt
@@ -4,6 +4,7 @@ import com.nshaddox.randomtask.domain.model.Task
 import com.nshaddox.randomtask.domain.repository.TaskRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 
 class FakeTaskRepository : TaskRepository {
@@ -12,10 +13,14 @@ class FakeTaskRepository : TaskRepository {
     private val tasksFlow = MutableStateFlow<List<Task>>(emptyList())
     private var nextId = 1L
 
-    override fun getTasks(): Flow<List<Task>> = tasksFlow
+    override fun getAllTasks(): Flow<List<Task>> = tasksFlow
 
-    override suspend fun getTaskById(id: Long): Task? {
-        return tasks.find { it.id == id }
+    override fun getIncompleteTasks(): Flow<List<Task>> {
+        return tasksFlow.map { list -> list.filter { !it.isCompleted } }
+    }
+
+    override fun getTaskById(id: Long): Flow<Task?> {
+        return tasksFlow.map { list -> list.find { it.id == id } }
     }
 
     override suspend fun addTask(task: Task): Result<Long> {
@@ -34,8 +39,8 @@ class FakeTaskRepository : TaskRepository {
         return Result.success(Unit)
     }
 
-    override suspend fun deleteTask(taskId: Long): Result<Unit> {
-        val removed = tasks.removeAll { it.id == taskId }
+    override suspend fun deleteTask(task: Task): Result<Unit> {
+        val removed = tasks.removeAll { it.id == task.id }
         if (!removed) return Result.failure(NoSuchElementException("Task not found"))
         tasksFlow.update { tasks.toList() }
         return Result.success(Unit)

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/UpdateTaskUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/UpdateTaskUseCaseTest.kt
@@ -22,24 +22,24 @@ class UpdateTaskUseCaseTest {
     @Test
     fun `invoke updates task successfully`() = runTest {
         repository.addTask(Task(title = "Original", createdAt = 1000L, updatedAt = 1000L))
-        val task = repository.getTasks().first().first()
+        val task = repository.getAllTasks().first().first()
         val updated = task.copy(title = "Updated")
 
         val result = updateTaskUseCase(updated)
 
         assertTrue(result.isSuccess)
-        val stored = repository.getTaskById(task.id)
+        val stored = repository.getTaskById(task.id).first()
         assertEquals("Updated", stored?.title)
     }
 
     @Test
     fun `invoke sets updatedAt timestamp`() = runTest {
         repository.addTask(Task(title = "Original", createdAt = 1000L, updatedAt = 1000L))
-        val task = repository.getTasks().first().first()
+        val task = repository.getAllTasks().first().first()
 
         updateTaskUseCase(task.copy(title = "Changed"))
 
-        val stored = repository.getTaskById(task.id)
+        val stored = repository.getTaskById(task.id).first()
         assertTrue(stored!!.updatedAt >= task.updatedAt)
     }
 }

--- a/docs/rpi/create-task-repository-interface.md
+++ b/docs/rpi/create-task-repository-interface.md
@@ -1,0 +1,37 @@
+# create-task-repository-interface
+
+**Implemented**: 2026-02-22
+**Complexity**: simple
+
+## What Changed
+
+- Updated `TaskRepository` interface to match issue #149 API: renamed `getTasks` to `getAllTasks`, added `getIncompleteTasks`, changed `getTaskById` to return `Flow<Task?>`, changed `deleteTask` to accept `Task`
+- Added `getTaskByIdFlow` to `TaskDao` returning `Flow<TaskEntity?>` for reactive single-task observation
+- Updated `TaskRepositoryImpl`, all use cases, `FakeTaskRepository`, and unit tests to match new signatures
+- Added KDoc documentation to the `TaskRepository` interface and all its methods
+
+## Why
+
+The repository interface needed to align with the API contract defined in issue #149. Key drivers: `getIncompleteTasks` moves filtering to the database layer for efficiency, `Flow<Task?>` on `getTaskById` enables reactive UI updates, and `deleteTask(task)` provides a safer API than raw ID deletion.
+
+## Key Files
+
+- `domain/repository/TaskRepository.kt` - Rewrote interface with new method names, signatures, and KDoc
+- `data/local/TaskDao.kt` - Added `getTaskByIdFlow` returning `Flow<TaskEntity?>`
+- `data/repository/TaskRepositoryImpl.kt` - Updated all overrides to match new interface
+- `domain/usecase/DeleteTaskUseCase.kt` - Changed parameter from `taskId: Long` to `Task`
+- `domain/usecase/GetRandomTaskUseCase.kt` - Uses `getIncompleteTasks()` instead of client-side filtering
+- `domain/usecase/GetTasksUseCase.kt` - Renamed `getTasks()` call to `getAllTasks()`
+- `test/.../FakeTaskRepository.kt` - Implemented all new interface methods
+- `test/.../DeleteTaskUseCaseTest.kt` - Updated to pass `Task` objects
+
+## Implementation Notes
+
+- Kept existing suspend `getTaskById` in DAO for backward compatibility; added `getTaskByIdFlow` alongside it
+- `FakeTaskRepository` derives `getIncompleteTasks` and `getTaskById` from `MutableStateFlow` using `.map`
+
+## Verification
+
+- [x] Tests: `./gradlew test` - BUILD SUCCESSFUL (all unit tests pass)
+- [x] Quality: `./gradlew assembleDebug` - BUILD SUCCESSFUL
+- [x] Manual: All 5 plan tasks verified complete, 10 files modified as expected


### PR DESCRIPTION
## Summary

- Defines the `TaskRepository` interface in `domain.repository` to match the Issue #149 spec: renames `getTasks` → `getAllTasks`, adds `getIncompleteTasks()`, changes `getTaskById` to return `Flow<Task?>`, changes `deleteTask` to accept a `Task` object, and adds KDoc documentation to all interface members
- Updates `TaskRepositoryImpl`, `TaskDao` (adds `getTaskByIdFlow`), all three affected use cases (`GetTasksUseCase`, `GetRandomTaskUseCase`, `DeleteTaskUseCase`), `FakeTaskRepository`, and four unit test files to match the new signatures
- All acceptance criteria from Issue #149 are satisfied; build and unit tests pass

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — BUILD SUCCESSFUL (all unit tests pass)
- [ ] Review `TaskRepository.kt` against Issue #149 acceptance criteria
- [ ] Verify KDoc on each method is present and accurate
- [ ] Confirm `FakeTaskRepository` correctly implements the updated interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)