### PR TITLE
feat(ui): create TaskListUiState data class (closes #63)

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
@@ -1,0 +1,18 @@
+package com.nshaddox.randomtask.ui.screens.tasklist
+
+import com.nshaddox.randomtask.domain.model.Task
+
+/**
+ * Represents the UI state of the task list screen.
+ *
+ * @property tasks The current list of tasks to display.
+ * @property isLoading Whether a loading operation is in progress.
+ * @property error An optional error message to display. Null when there is no error.
+ * @property showAddDialog Whether the add-task dialog is currently visible.
+ */
+data class TaskListUiState(
+    val tasks: List<Task> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val showAddDialog: Boolean = false
+)

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
@@ -1,0 +1,95 @@
+package com.nshaddox.randomtask.ui.screens.tasklist
+
+import com.nshaddox.randomtask.domain.model.Task
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TaskListUiStateTest {
+
+    @Test
+    fun `default state has empty task list`() {
+        val state = TaskListUiState()
+        assertTrue(state.tasks.isEmpty())
+    }
+
+    @Test
+    fun `default state is not loading`() {
+        val state = TaskListUiState()
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `default state has no error`() {
+        val state = TaskListUiState()
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `default state has add dialog hidden`() {
+        val state = TaskListUiState()
+        assertFalse(state.showAddDialog)
+    }
+
+    @Test
+    fun `copy to loading state`() {
+        val state = TaskListUiState()
+        val loading = state.copy(isLoading = true)
+        assertTrue(loading.isLoading)
+        assertTrue(loading.tasks.isEmpty())
+        assertNull(loading.error)
+        assertFalse(loading.showAddDialog)
+    }
+
+    @Test
+    fun `copy to error state`() {
+        val state = TaskListUiState(isLoading = true)
+        val error = state.copy(isLoading = false, error = "Something went wrong")
+        assertFalse(error.isLoading)
+        assertEquals("Something went wrong", error.error)
+    }
+
+    @Test
+    fun `copy to show add dialog`() {
+        val state = TaskListUiState()
+        val withDialog = state.copy(showAddDialog = true)
+        assertTrue(withDialog.showAddDialog)
+    }
+
+    @Test
+    fun `copy with tasks`() {
+        val tasks = listOf(
+            Task(id = 1, title = "Task 1", createdAt = 1000L, updatedAt = 1000L),
+            Task(id = 2, title = "Task 2", createdAt = 2000L, updatedAt = 2000L)
+        )
+        val state = TaskListUiState().copy(tasks = tasks)
+        assertEquals(2, state.tasks.size)
+        assertEquals("Task 1", state.tasks[0].title)
+        assertEquals("Task 2", state.tasks[1].title)
+    }
+
+    @Test
+    fun `equality for identical states`() {
+        val state1 = TaskListUiState()
+        val state2 = TaskListUiState()
+        assertEquals(state1, state2)
+    }
+
+    @Test
+    fun `equality for states with same tasks`() {
+        val task = Task(id = 1, title = "Task", createdAt = 1000L, updatedAt = 1000L)
+        val state1 = TaskListUiState(tasks = listOf(task), isLoading = true)
+        val state2 = TaskListUiState(tasks = listOf(task), isLoading = true)
+        assertEquals(state1, state2)
+    }
+
+    @Test
+    fun `toString contains field values`() {
+        val state = TaskListUiState(isLoading = true, error = "fail")
+        val str = state.toString()
+        assertTrue(str.contains("isLoading=true"))
+        assertTrue(str.contains("error=fail"))
+    }
+}

--- a/docs/rpi/create-task-list-ui-state.md
+++ b/docs/rpi/create-task-list-ui-state.md
@@ -1,0 +1,31 @@
+# create-task-list-ui-state
+
+**Implemented**: 2026-02-22
+**Complexity**: simple
+
+## What Changed
+
+- Added `TaskListUiState` data class to represent unified UI state for the task list screen
+- Added unit tests covering default values, copy transitions, equality, and toString behavior
+
+## Why
+
+The task list screen needs a single state object for a future ViewModel to expose via `StateFlow<TaskListUiState>`. This replaces passing raw `List<Task>` and individual callbacks, establishing the UiState pattern for the project's MVVM architecture.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt` - New data class with four fields: tasks, isLoading, error, showAddDialog
+- `app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt` - 11 unit tests for defaults, copy, equality, and toString
+
+## Implementation Notes
+
+- Followed KDoc convention established in `domain/model/Task.kt`
+- Uses domain `Task` model (not preview mock) as the list element type
+- Pure Kotlin data class with no Compose, Hilt, or ViewModel dependencies
+- All fields have safe defaults: emptyList(), false, null, false
+
+## Verification
+
+- [x] Tests: `./gradlew testDebugUnitTest --tests TaskListUiStateTest` passed
+- [x] Quality: `./gradlew assembleDebug` and `./gradlew test` passed (no regressions)
+- [x] Manual: File structure and KDoc verified against plan


### PR DESCRIPTION
## Summary

- Defines `TaskListUiState` data class in `ui.screens.tasklist` package with four fields: `tasks: List<Task>`, `isLoading: Boolean`, `error: String?`, `showAddDialog: Boolean`
- Establishes the UI state pattern for the task list screen, setting the convention for future screens
- Adds 10 unit tests covering default values, `copy()` state transitions, equality, and `toString`

Closes #63

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- [x] Unit tests added — `TaskListUiStateTest` covers defaults, transitions, equality, and toString
- [x] Build passes: `./gradlew assembleDebug`
- [x] Full test suite passes: `./gradlew test`
- [x] Pre-commit hooks (lint + unit tests) passed at commit time
