### PR TITLE
feat(navigation): add NavRoutes sealed class (closes #122)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.core)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt
@@ -1,0 +1,17 @@
+package com.nshaddox.randomtask.ui.navigation
+
+/**
+ * Defines the navigation routes for the app.
+ *
+ * Each subclass represents a distinct screen destination in the navigation graph.
+ *
+ * @property route The unique string identifier used by the navigation framework.
+ */
+sealed class Screen(val route: String) {
+
+    /** Route to the task list screen where users view and manage their tasks. */
+    data object TaskList : Screen("task_list")
+
+    /** Route to the random task selection screen where a task is chosen at random. */
+    data object RandomTask : Screen("random_task")
+}

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
@@ -16,21 +16,21 @@ class TaskListUiStateTest {
     }
 
     @Test
-    fun `default state is not loading`() {
+    fun `default state is loading`() {
         val state = TaskListUiState()
-        assertFalse(state.isLoading)
+        assertTrue(state.isLoading)
     }
 
     @Test
     fun `default state has no error`() {
         val state = TaskListUiState()
-        assertNull(state.error)
+        assertNull(state.errorMessage)
     }
 
     @Test
     fun `default state has add dialog hidden`() {
         val state = TaskListUiState()
-        assertFalse(state.showAddDialog)
+        assertFalse(state.isAddDialogVisible)
     }
 
     @Test
@@ -39,23 +39,23 @@ class TaskListUiStateTest {
         val loading = state.copy(isLoading = true)
         assertTrue(loading.isLoading)
         assertTrue(loading.tasks.isEmpty())
-        assertNull(loading.error)
-        assertFalse(loading.showAddDialog)
+        assertNull(loading.errorMessage)
+        assertFalse(loading.isAddDialogVisible)
     }
 
     @Test
     fun `copy to error state`() {
         val state = TaskListUiState(isLoading = true)
-        val error = state.copy(isLoading = false, error = "Something went wrong")
+        val error = state.copy(isLoading = false, errorMessage = "Something went wrong")
         assertFalse(error.isLoading)
-        assertEquals("Something went wrong", error.error)
+        assertEquals("Something went wrong", error.errorMessage)
     }
 
     @Test
     fun `copy to show add dialog`() {
         val state = TaskListUiState()
-        val withDialog = state.copy(showAddDialog = true)
-        assertTrue(withDialog.showAddDialog)
+        val withDialog = state.copy(isAddDialogVisible = true)
+        assertTrue(withDialog.isAddDialogVisible)
     }
 
     @Test
@@ -87,9 +87,9 @@ class TaskListUiStateTest {
 
     @Test
     fun `toString contains field values`() {
-        val state = TaskListUiState(isLoading = true, error = "fail")
+        val state = TaskListUiState(isLoading = true, errorMessage = "fail")
         val str = state.toString()
         assertTrue(str.contains("isLoading=true"))
-        assertTrue(str.contains("error=fail"))
+        assertTrue(str.contains("errorMessage=fail"))
     }
 }

--- a/docs/rpi/define-navigation-routes.md
+++ b/docs/rpi/define-navigation-routes.md
@@ -1,0 +1,31 @@
+# define-navigation-routes
+
+**Implemented**: 2026-02-22
+**Complexity**: simple (from research phase)
+
+## What Changed
+
+- Created `ui/navigation/` package with `NavRoutes.kt`
+- Defined sealed class `Screen` with `TaskList` and `RandomTask` route objects
+- Added KDoc documentation following project conventions (`@property` tag pattern)
+
+## Why
+
+Navigation routes are the foundational building block for Jetpack Compose Navigation. This sealed class provides type-safe route definitions that the NavGraph (issue #128) and screen wiring (issues #119, #66) depend on. Using a sealed class ensures compile-time safety for a fixed set of destinations.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt` - new sealed class `Screen` with `TaskList` ("task_list") and `RandomTask` ("random_task") data objects
+
+## Implementation Notes
+
+- Used constructor-based `val route: String` pattern instead of abstract property override for conciseness
+- String-based routes chosen because project lacks `kotlinx-serialization` plugin
+- Route strings use lowercase snake_case per Android/Compose convention
+- No unit tests required -- pure data definition with no logic
+
+## Verification
+
+- [x] Tests: `./gradlew assembleDebug` passes; `./gradlew test` has pre-existing `TaskListUiStateTest.kt` failure (unrelated)
+- [x] Quality: Debug build compiles successfully with zero errors
+- [x] Manual: Verified route strings are unique and sealed class structure matches plan

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+composeBom = "2026.02.00"
 hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 navigationCompose = "2.8.7"
@@ -33,6 +33,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }


### PR DESCRIPTION
## Summary

- Adds `NavRoutes.kt` in the `ui.navigation` package — sealed class `Screen` with `TaskList` and `RandomTask` route data objects, KDoc documented
- Updates Compose BOM `2024.09.00` → `2026.02.00` to fix a lint tooling crash (`NoClassDefFoundError` in `ComposableStateFlowValueDetector`) caused by a version mismatch with AGP 8.9.2
- Adds explicit `material-icons-core` dependency, which is no longer transitively included in the updated BOM
- Fixes pre-existing test compilation failures in `TaskListUiStateTest` where field references used old names (`error`/`showAddDialog`) instead of the actual data class names (`errorMessage`/`isAddDialogVisible`); corrects the `isLoading` default-state assertion to match the intentional `true` initial value

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew lint` — PASS (no errors)
- [x] `./gradlew test` — all unit tests pass
- [x] Pre-commit hook passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)