### PR TITLE
feat(ui): implement RandomTaskScreen with ViewModel integration

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/ui/preview/MockData.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/preview/MockData.kt
@@ -33,4 +33,13 @@ object SampleData {
         createdAt = 1_700_000_000_000L,
         updatedAt = 1_700_000_000_000L
     )
+
+    val sampleTaskWithDescription = Task(
+        id = 100L,
+        title = "Refactor authentication module",
+        description = "Extract shared auth logic into a reusable middleware and add unit tests for token validation",
+        isCompleted = false,
+        createdAt = 1_700_000_000_000L,
+        updatedAt = 1_700_000_000_000L
+    )
 }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/randomtask/RandomTaskScreen.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/randomtask/RandomTaskScreen.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -25,34 +29,76 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
 import com.nshaddox.randomtask.domain.model.Task
 
 /**
- * Random Task Selection Screen - Displays a randomly selected task from the list
+ * Stateful Random Task Screen that integrates with ViewModel and NavController.
  *
- * @param selectedTask The task that was randomly selected, or null if no tasks available
+ * @param navController Navigation controller for back navigation
+ * @param viewModel Hilt-injected ViewModel managing random task state
+ */
+@Composable
+fun RandomTaskScreen(
+    navController: NavController,
+    viewModel: RandomTaskViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadRandomTask()
+    }
+
+    RandomTaskScreenContent(
+        uiState = uiState,
+        onSelectRandom = viewModel::loadRandomTask,
+        onCompleteTask = viewModel::completeTask,
+        onSkipTask = viewModel::skipTask,
+        onBackClick = { navController.popBackStack() }
+    )
+}
+
+/**
+ * Stateless Random Task Screen content for preview support.
+ *
+ * @param uiState Current UI state for the random task screen
  * @param onSelectRandom Callback to select a new random task
  * @param onCompleteTask Callback when the user marks the task as complete
  * @param onSkipTask Callback when the user wants to skip this task
+ * @param onBackClick Callback for back navigation
  * @param modifier Modifier for customization
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RandomTaskScreen(
-    selectedTask: Task?,
+internal fun RandomTaskScreenContent(
+    uiState: RandomTaskUiState,
     onSelectRandom: () -> Unit = {},
     onCompleteTask: () -> Unit = {},
     onSkipTask: () -> Unit = {},
+    onBackClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Random Task") },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
@@ -68,17 +114,34 @@ fun RandomTaskScreen(
                 .padding(16.dp),
             contentAlignment = Alignment.Center
         ) {
-            if (selectedTask == null) {
-                NoTaskSelectedContent(
-                    onSelectRandom = onSelectRandom
-                )
-            } else {
-                SelectedTaskContent(
-                    task = selectedTask,
-                    onSelectRandom = onSelectRandom,
-                    onCompleteTask = onCompleteTask,
-                    onSkipTask = onSkipTask
-                )
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator()
+                }
+                uiState.error != null -> {
+                    ErrorContent(
+                        error = uiState.error,
+                        onRetry = onSelectRandom
+                    )
+                }
+                uiState.noTasksAvailable -> {
+                    NoTasksAvailableContent(
+                        onBackClick = onBackClick
+                    )
+                }
+                uiState.currentTask != null -> {
+                    SelectedTaskContent(
+                        task = uiState.currentTask,
+                        onSelectRandom = onSelectRandom,
+                        onCompleteTask = onCompleteTask,
+                        onSkipTask = onSkipTask
+                    )
+                }
+                else -> {
+                    NoTaskSelectedContent(
+                        onSelectRandom = onSelectRandom
+                    )
+                }
             }
         }
     }
@@ -122,6 +185,56 @@ private fun NoTaskSelectedContent(
 }
 
 @Composable
+private fun ErrorContent(
+    error: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = error,
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.error
+        )
+        OutlinedButton(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}
+
+@Composable
+private fun NoTasksAvailableContent(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "No tasks available. Add some tasks first!",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        OutlinedButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Text("Go Back")
+        }
+    }
+}
+
+@Composable
 private fun SelectedTaskContent(
     task: Task,
     onSelectRandom: () -> Unit,
@@ -147,11 +260,11 @@ private fun SelectedTaskContent(
             ),
             elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
         ) {
-            Box(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(32.dp),
-                contentAlignment = Alignment.Center
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
                     text = task.title,
@@ -159,6 +272,15 @@ private fun SelectedTaskContent(
                     textAlign = TextAlign.Center,
                     color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
+                if (task.description != null) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = task.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
             }
         }
 
@@ -170,7 +292,11 @@ private fun SelectedTaskContent(
         ) {
             Button(
                 onClick = onCompleteTask,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF4CAF50),
+                    contentColor = Color.White
+                )
             ) {
                 Icon(
                     imageVector = Icons.Default.Done,

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/randomtask/RandomTaskScreenPreview.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/randomtask/RandomTaskScreenPreview.kt
@@ -13,21 +13,21 @@ import com.nshaddox.randomtask.ui.theme.RandomTaskTheme
 @Composable
 fun RandomTaskScreenWithTaskPreview() {
     RandomTaskTheme {
-        RandomTaskScreen(
-            selectedTask = SampleData.singleTask
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(currentTask = SampleData.singleTask)
         )
     }
 }
 
 /**
- * Preview for RandomTaskScreen with no task selected (empty state)
+ * Preview for RandomTaskScreen with no task selected (empty/initial state)
  */
 @Preview(showBackground = true)
 @Composable
 fun RandomTaskScreenEmptyPreview() {
     RandomTaskTheme {
-        RandomTaskScreen(
-            selectedTask = null
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState()
         )
     }
 }
@@ -39,8 +39,60 @@ fun RandomTaskScreenEmptyPreview() {
 @Composable
 fun RandomTaskScreenShortTitlePreview() {
     RandomTaskTheme {
-        RandomTaskScreen(
-            selectedTask = SampleData.sampleTask
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(currentTask = SampleData.sampleTask)
+        )
+    }
+}
+
+/**
+ * Preview for RandomTaskScreen in loading state
+ */
+@Preview(showBackground = true)
+@Composable
+fun RandomTaskScreenLoadingPreview() {
+    RandomTaskTheme {
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(isLoading = true)
+        )
+    }
+}
+
+/**
+ * Preview for RandomTaskScreen in error state
+ */
+@Preview(showBackground = true)
+@Composable
+fun RandomTaskScreenErrorPreview() {
+    RandomTaskTheme {
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(error = "Something went wrong")
+        )
+    }
+}
+
+/**
+ * Preview for RandomTaskScreen with no tasks available
+ */
+@Preview(showBackground = true)
+@Composable
+fun RandomTaskScreenNoTasksPreview() {
+    RandomTaskTheme {
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(noTasksAvailable = true)
+        )
+    }
+}
+
+/**
+ * Preview for RandomTaskScreen with a task that has a description
+ */
+@Preview(showBackground = true)
+@Composable
+fun RandomTaskScreenWithDescriptionPreview() {
+    RandomTaskTheme {
+        RandomTaskScreenContent(
+            uiState = RandomTaskUiState(currentTask = SampleData.sampleTaskWithDescription)
         )
     }
 }

--- a/docs/rpi/implement-random-task-screen.md
+++ b/docs/rpi/implement-random-task-screen.md
@@ -1,0 +1,35 @@
+# implement-random-task-screen
+
+**Implemented**: 2026-02-28
+**Complexity**: medium (from research phase)
+
+## What Changed
+
+- Refactored `RandomTaskScreen` into a two-layer composable: outer stateful (ViewModel + NavController) and inner stateless (`RandomTaskScreenContent`) for preview support
+- Added loading spinner, error-with-retry, and no-tasks-available UI states driven by `RandomTaskUiState`
+- Added back navigation arrow in `TopAppBar`, task description display in the card, and green Complete button
+- Updated all preview functions to use `RandomTaskScreenContent` with explicit `RandomTaskUiState` instances
+- Added `sampleTaskWithDescription` to `SampleData` for preview coverage
+
+## Why
+
+Issue #61 required the existing stateless `RandomTaskScreen` to become a fully functional ViewModel-connected screen with proper state handling, navigation, and polished UI. This completes the random task selection feature's UI layer.
+
+## Key Files
+
+- `app/.../screens/randomtask/RandomTaskScreen.kt` - Two-layer composable with all UI states, back nav, description display, green Complete button
+- `app/.../screens/randomtask/RandomTaskScreenPreview.kt` - Seven previews covering task, task+description, empty, loading, error, and no-tasks states
+- `app/.../ui/preview/MockData.kt` - Added `sampleTaskWithDescription` with non-null description field
+
+## Implementation Notes
+
+- Followed `TaskEditorScreen` pattern for back navigation with `Icons.AutoMirrored.Filled.ArrowBack`
+- Green Complete button uses `ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50))`
+- `LaunchedEffect(Unit)` triggers `loadRandomTask()` on first composition
+- Card interior changed from `Box` to `Column` to stack title and optional description
+
+## Verification
+
+- [x] Tests: `./gradlew test` -- all tests pass (BUILD SUCCESSFUL)
+- [x] Quality: `./gradlew assembleDebug` -- compiles successfully (BUILD SUCCESSFUL)
+- [x] Plan: All 4 parent tasks and 16 sub-tasks marked complete


### PR DESCRIPTION
Closes #61

## Summary

- Refactors \`RandomTaskScreen\` into a two-layer composable pattern (stateful outer + stateless inner) to support both Hilt ViewModel integration and Compose Previews
- Adds all missing UI states: loading (\`CircularProgressIndicator\`), error with Retry button, no-tasks-available with Go Back button
- Adds back navigation arrow in \`TopAppBar\` (popBackStack)
- Displays task description (nullable, shown only when present)
- Applies green color (#4CAF50) to the Complete button as the primary action

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Plan

- [x] \`./gradlew test\` — all unit tests pass
- [x] \`./gradlew assembleDebug\` — clean build, no lint warnings
- [ ] Manual: navigate to Random Task screen and verify each UI state

## Files Changed

| File | Change |
|------|--------|
| \`RandomTaskScreen.kt\` | Major refactor — two-layer composable, all UI states |
| \`RandomTaskScreenPreview.kt\` | Updated to \`RandomTaskScreenContent\`; added 4 new state previews |
| \`MockData.kt\` | Added \`sampleTaskWithDescription\` for preview support |
| \`docs/rpi/implement-random-task-screen.md\` | RPI implementation summary |