### PR TITLE
docs: add AI-native development documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Random Task is a native Android app built with Kotlin and Jetpack Compose that helps users manage tasks by randomly selecting one from their list. The app follows MVVM architecture and is designed for simplicity and performance.
+Random Task is a native Android app built with Kotlin and Jetpack Compose that helps users manage tasks by randomly selecting one from their list. The app follows MVVM architecture with clean separation between data, domain, and presentation layers.
 
 **Core Functionality:**
 - Add, edit, delete, and view tasks
@@ -12,124 +12,124 @@ Random Task is a native Android app built with Kotlin and Jetpack Compose that h
 - Mark tasks as completed or skip them
 - Persist task data locally with Room Database
 
-**Current Status:** Initial project setup phase. The project structure is established, but core features are not yet implemented. See `the-idea/project-roadmap.md` for detailed implementation phases.
+**Current Status:** v1.0 features complete. v2.0 development planned (priority, due dates, categories, search/filter/sort, settings, completed tasks history).
+
+## Documentation
+
+The `docs/` directory contains detailed guides. **Read them on-demand, not upfront.**
+
+- **`docs/ARCHITECTURE.md`** — Read when making architectural decisions, adding new layers/modules, or needing to understand data flow and design patterns.
+- **`docs/DEVELOPMENT.md`** — Read when setting up the project, adding dependencies, or troubleshooting build/environment issues.
+- **`docs/TESTING.md`** — Read when writing or debugging tests, or when you need test patterns and the coroutine testing checklist.
+- **`docs/PRECOMMIT.md`** — Read when a pre-commit hook fails, or when modifying the hook configuration.
 
 ## Build Commands
 
 ```bash
-# Build the app (debug variant)
+# Build debug variant
 ./gradlew assembleDebug
-
-# Build release variant
-./gradlew assembleRelease
 
 # Run unit tests
 ./gradlew test
 
-# Run instrumented tests on connected device/emulator
+# Run specific test class
+./gradlew test --tests com.nshaddox.randomtask.domain.usecase.AddTaskUseCaseTest
+
+# Run lint + tests (same as pre-commit hook)
+./gradlew lintDebug testDebugUnitTest
+
+# Run instrumented tests (requires device/emulator)
 ./gradlew connectedAndroidTest
 
-# Run specific test class
-./gradlew test --tests com.nshaddox.randomtask.YourTestClass
-
-# Clean build artifacts
-./gradlew clean
-
-# Install debug build to connected device
-./gradlew installDebug
-
-# View all available tasks
-./gradlew tasks
-
-# Install Git hooks (pre-commit checks)
+# Install pre-commit hooks
 ./gradlew installGitHooks
-```
 
-**Git Hooks:**
-- Pre-commit hook runs lint and unit tests before each commit
-- Ensures code quality before changes reach the repository
-- Skip with `git commit --no-verify` if needed (use sparingly)
-- Hook files are stored in `git-hooks/` and installed via Gradle task
+# Clean build
+./gradlew clean assembleDebug
+```
 
 ## Technical Stack
 
-- **Language:** Kotlin
+- **Language:** Kotlin 2.0.21
 - **UI Framework:** Jetpack Compose with Material3
-- **Architecture:** MVVM (Model-View-ViewModel)
-- **Database:** Room (SQLite) - *to be implemented*
-- **Dependency Injection:** Hilt - *to be implemented*
-- **Async Operations:** Kotlin Coroutines - *to be implemented*
-- **Navigation:** Navigation Component - *to be implemented*
-- **Min SDK:** 24 (Android 7.0)
-- **Target SDK:** 35
+- **Architecture:** MVVM with clean architecture layers (data/domain/ui)
+- **Database:** Room 2.8.4
+- **Dependency Injection:** Hilt 2.51.1 (via KSP)
+- **Async:** Kotlin Coroutines 1.10.2, Flow
+- **Navigation:** Navigation Compose 2.8.7
+- **Testing:** JUnit 4, MockK, Turbine, coroutines-test
+- **Min SDK:** 24 / **Target SDK:** 35
+
+## Architecture at a Glance
+
+```
+Presentation (Compose Screens → ViewModels → UiState)
+    ↓ uses
+Domain (Use Cases → Repository Interface → Task Model)
+    ↓ implements
+Data (Room DAO → TaskEntity → TaskRepositoryImpl → Mappers)
+```
+
+- **Domain layer has zero Android dependencies** — pure Kotlin
+- Queries return `Flow<T>`, mutations return `Result<T>`
+- ViewModels expose `StateFlow<UiState>`
+- Named dispatchers injected via Hilt for testability
 
 ## Project Structure
 
 ```
 app/src/main/java/com/nshaddox/randomtask/
-├── MainActivity.kt              # Main entry point
-└── ui/
-    └── theme/                   # Compose theme definitions
-        ├── Color.kt
-        ├── Theme.kt
-        └── Type.kt
-```
-
-**Planned Structure** (as architecture is implemented):
-```
-app/src/main/java/com/nshaddox/randomtask/
 ├── data/
-│   ├── local/                   # Room database entities, DAOs
-│   └── repository/              # Repository implementations
+│   ├── local/          # AppDatabase, TaskDao, TaskEntity
+│   └── repository/     # TaskRepositoryImpl, TaskMappers
+├── di/                 # DatabaseModule, RepositoryModule, CoroutineModule
 ├── domain/
-│   ├── model/                   # Domain models
-│   └── usecase/                 # Business logic use cases
-├── ui/
-│   ├── tasklist/                # Task list screen
-│   ├── randomtask/              # Random task selection screen
-│   └── theme/                   # Theme definitions
-└── di/                          # Hilt dependency injection modules
+│   ├── model/          # Task data class
+│   ├── repository/     # TaskRepository interface
+│   └── usecase/        # GetTasks, GetRandom, Add, Update, Complete, Delete
+└── ui/
+    ├── navigation/     # NavRoutes (Screen sealed class), NavGraph
+    ├── screens/
+    │   ├── tasklist/   # TaskListScreen, ViewModel, UiState, AddTaskDialog
+    │   ├── randomtask/ # RandomTaskScreen, ViewModel, UiState
+    │   └── taskeditor/ # TaskEditorScreen, ViewModel
+    ├── preview/        # MockData (SampleData for Compose previews)
+    └── theme/          # Color, Theme, Type
 ```
 
-## Architecture Guidelines
+## Testing Summary
 
-**MVVM Pattern:**
-- **Model:** Data layer (Room entities, repositories)
-- **View:** Jetpack Compose UI components
-- **ViewModel:** Manages UI state and business logic, exposes StateFlow/LiveData
+- **16 unit test files** covering use cases, ViewModels, mappers, and UI state
+- `FakeTaskRepository` — in-memory test implementation using `MutableStateFlow`
+- ViewModel tests use `StandardTestDispatcher` + Turbine for Flow assertions
+- Pre-commit hook runs `lintDebug` + `testDebugUnitTest` before every commit
+- CI runs the same checks via GitHub Actions
 
-**Key Principles:**
-- UI state should be hoisted to ViewModels
-- Use Kotlin Flows for reactive data streams
-- Repository pattern abstracts data sources
-- Dependency injection via Hilt for testability
-- Single Activity architecture with Compose Navigation
+Read `docs/TESTING.md` when writing or debugging tests.
 
-## Development Notes
+## Development Guardrails
 
-**Observability:**
-- OpenTelemetry instrumentation planned for development builds only
-- Will use debug-only dependencies to avoid production overhead
-- Focus on database operations and UI rendering paths
-- See `the-idea/observability-strategy.md` for implementation details
+- **Pre-commit hook** runs lint and unit tests — do not skip to avoid fixing failures
+- **Branch naming:** `issue-{number}-{short-description}`
+- **All new code must have tests** — test use cases, ViewModels, and mappers
+- **Domain layer stays pure Kotlin** — no Android imports in `domain/`
+- **Use named dispatchers** — inject `@Named("IO")` instead of hardcoding `Dispatchers.IO`
+- **Mappers are extension functions** — no mapper classes, no business logic in mappers
 
-**Data Persistence:**
-- Room Database will be the primary storage mechanism
-- ACID-compliant local storage for tasks
-- No cloud sync in MVP (post-MVP feature)
+## Review Checklist
 
-**Testing Strategy:**
-- Unit tests for ViewModels and repositories
-- Integration tests for database operations
-- UI tests with Compose Testing library
-- Test files located in `app/src/test/` (unit) and `app/src/androidTest/` (instrumented)
+Before committing:
+
+- [ ] All tests pass (`./gradlew test`)
+- [ ] Lint passes (`./gradlew lintDebug`)
+- [ ] New code has corresponding tests
+- [ ] No hardcoded strings in UI (use string resources)
+- [ ] Domain layer has no Android imports
+- [ ] Pre-commit hook passes
 
 ## Important Context
 
-The `the-idea/` directory contains comprehensive planning documents that define the project vision:
-- `core-requirements.md` - Functional and non-functional requirements
-- `technical-options.md` - Architecture decisions and technical stack rationale
-- `observability-strategy.md` - Development observability approach
-- `project-roadmap.md` - Phased implementation plan
-
-These documents should be consulted when making architectural decisions or implementing new features to ensure alignment with the original vision.
+- `the-idea/` — Planning documents (requirements, technical decisions, roadmap)
+- `docs/` — Development documentation (architecture, testing, pre-commit)
+- `GITHUB_ISSUES_V1_5.md` — v1.5 milestone: dev tooling and foundations
+- `GITHUB_ISSUES_V2.md` — v2.0 milestone: feature expansion (33 issues, 10 groups)

--- a/GITHUB_ISSUES_V1_5.md
+++ b/GITHUB_ISSUES_V1_5.md
@@ -1,0 +1,158 @@
+# Random Task App — v1.5 Dev Tooling & Foundations GitHub Issues
+
+**Milestone**: v1.5
+**Total Issues**: 5
+**Purpose**: Developer experience improvements and UI foundations to set up before v2.0 feature work.
+
+| Group                          | Issues         | What it unlocks                        |
+|--------------------------------|----------------|----------------------------------------|
+| 1 — Code Quality Tooling      | #101, #110     | Consistent code style for v2.0 work    |
+| 2 — Issue Templates           | #73, #79       | Better issue tracking for v2.0         |
+| 3 — UI Foundations             | #143           | Consistent spacing across v2.0 screens |
+
+---
+
+## Group 1: Code Quality Tooling
+*No dependencies. Should be done first so all v2.0 code is linted from the start.*
+
+---
+
+### Issue #101: Configure ktlint for code formatting
+**Labels**: `v1.5`, `setup`, `code-quality`, `P1-high`
+**Estimated Complexity**: Medium
+**Branch**: `issue-101-ktlint`
+
+**Description**:
+Add ktlint for consistent Kotlin code formatting across the project. Setting this up before
+v2.0 ensures all new code follows the same style from day one.
+
+**Acceptance Criteria**:
+- [ ] ktlint Gradle plugin added to `build.gradle.kts`
+- [ ] Configuration file `.editorconfig` created with project standards
+- [ ] Gradle task `./gradlew ktlintCheck` runs successfully
+- [ ] Gradle task `./gradlew ktlintFormat` auto-fixes formatting issues
+- [ ] ktlint integrated into CI/CD pipeline (GitHub Actions)
+- [ ] Existing code passes ktlint checks
+
+**Dependencies**: None
+
+---
+
+### Issue #110: Configure detekt for static analysis
+**Labels**: `v1.5`, `setup`, `code-quality`, `P1-high`
+**Estimated Complexity**: Medium
+**Branch**: `issue-110-detekt`
+
+**Description**:
+Add detekt for static code analysis to catch potential bugs and code smells.
+Having this in place before v2.0 prevents tech debt from accumulating across 33 new issues.
+
+**Acceptance Criteria**:
+- [ ] detekt Gradle plugin added to `build.gradle.kts`
+- [ ] Configuration file `detekt.yml` created with project rules
+- [ ] Gradle task `./gradlew detekt` runs successfully
+- [ ] detekt integrated into CI/CD pipeline (GitHub Actions)
+- [ ] Baseline file generated for existing code if needed
+- [ ] Critical issues resolved
+
+**Dependencies**: None
+
+---
+
+## Group 2: Issue Templates
+*No dependencies. Quick wins for better v2.0 issue management.*
+
+---
+
+### Issue #73: Create bug report issue template
+**Labels**: `v1.5`, `documentation`, `setup`, `P1-high`
+**Estimated Complexity**: Low
+**Branch**: `issue-73-bug-template`
+
+**Description**:
+Create a standardized bug report template to help provide necessary information when
+reporting bugs during v2.0 development.
+
+**Acceptance Criteria**:
+- [ ] File created at `.github/ISSUE_TEMPLATE/bug_report.md`
+- [ ] Template includes sections for:
+  - Bug description
+  - Steps to reproduce
+  - Expected behavior
+  - Actual behavior
+  - Device/OS information
+  - App version
+  - Screenshots (optional)
+- [ ] Template is available when creating new issues
+
+**Dependencies**: None
+
+---
+
+### Issue #79: Create feature request issue template
+**Labels**: `v1.5`, `documentation`, `setup`, `P1-high`
+**Estimated Complexity**: Low
+**Branch**: `issue-79-feature-template`
+
+**Description**:
+Create a standardized feature request template to help suggest new features with proper context.
+
+**Acceptance Criteria**:
+- [ ] File created at `.github/ISSUE_TEMPLATE/feature_request.md`
+- [ ] Template includes sections for:
+  - Feature description
+  - Use case/problem it solves
+  - Proposed solution
+  - Alternative solutions considered
+  - Additional context
+- [ ] Template is available when creating new issues
+
+**Dependencies**: None
+
+---
+
+## Group 3: UI Foundations
+*No dependencies. Sets up consistent spacing before v2.0 UI work begins.*
+
+---
+
+### Issue #143: Create dimensions and spacing system
+**Labels**: `v1.5`, `ui`, `theme`, `P2-medium`
+**Estimated Complexity**: Low
+**Branch**: `issue-143-spacing`
+
+**Description**:
+Define consistent spacing and dimension values for the UI. v2.0 introduces several new
+screens and components — having a shared spacing system ensures visual consistency and
+reduces hardcoded `.dp` values scattered across composables.
+
+**Acceptance Criteria**:
+- [ ] File created: `Dimensions.kt` in `ui.theme` package
+- [ ] Object defining spacing values:
+  ```kotlin
+  object Spacing {
+      val extraSmall = 4.dp
+      val small = 8.dp
+      val medium = 16.dp
+      val large = 24.dp
+      val extraLarge = 32.dp
+  }
+  ```
+- [ ] Object defining common sizes (icon sizes, button heights, etc.)
+- [ ] Existing composables updated to use `Spacing.*` instead of hardcoded values
+- [ ] Used consistently across UI components
+
+**Dependencies**: None
+
+---
+
+## Issues moved to v2.0
+
+The following UI polish issues should be addressed as part of v2.0 feature work:
+
+| Issue | Title                                    |
+|-------|------------------------------------------|
+| #84   | Implement loading states with shimmer effects |
+| #92   | Add animations and transitions           |
+| #96   | Create empty state illustrations         |
+| #105  | Add haptic feedback                      |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,285 @@
+# Architecture Guide
+
+This document describes the architecture, design patterns, and technical decisions of the Random Task application.
+
+## Overview
+
+Random Task is a native Android application built with Kotlin and Jetpack Compose that helps users manage tasks by randomly selecting one from their list. It follows MVVM architecture with clean separation between data, domain, and presentation layers.
+
+## Technology Stack
+
+### Core Framework
+
+- **Kotlin 2.0.21** — Primary language
+- **Jetpack Compose (BOM 2026.02.00)** — Declarative UI framework
+- **Material3** — Design system and theming
+- **Hilt 2.51.1** — Dependency injection via KSP
+- **Navigation Compose 2.8.7** — Single-activity navigation
+
+### Data Layer
+
+- **Room 2.8.4** — SQLite abstraction with compile-time query verification
+- **Kotlin Coroutines 1.10.2** — Asynchronous operations
+- **Kotlin Flow** — Reactive data streams
+
+### Build and Tooling
+
+- **Gradle (Kotlin DSL)** — Build system
+- **Android Gradle Plugin 8.9.2** — Android build toolchain
+- **KSP 2.0.21-1.0.28** — Kotlin Symbol Processing for annotation processors
+- **Version Catalog (`libs.versions.toml`)** — Centralized dependency management
+
+### Platform Targets
+
+- **Min SDK:** 24 (Android 7.0)
+- **Target SDK:** 35 (Android 15)
+- **Compile SDK:** 35
+- **Java/Kotlin Target:** JVM 11
+
+## Architectural Patterns
+
+### MVVM with Clean Architecture Layers
+
+The application follows a three-layer architecture with unidirectional data flow:
+
+```
+┌─────────────────────────────────────────────────┐
+│                Presentation Layer                │
+│  Screens (Compose) → ViewModels → UiState        │
+│  Navigation, Theme, Preview                      │
+├─────────────────────────────────────────────────┤
+│                  Domain Layer                    │
+│  Use Cases → Repository Interface → Task Model   │
+│  Pure Kotlin, no Android dependencies            │
+├─────────────────────────────────────────────────┤
+│                   Data Layer                     │
+│  Room DAO → TaskEntity → TaskRepositoryImpl      │
+│  Mappers (Entity ↔ Domain)                       │
+├─────────────────────────────────────────────────┤
+│              Dependency Injection                 │
+│  Hilt Modules: Database, Repository, Coroutine   │
+└─────────────────────────────────────────────────┘
+```
+
+**Key rule:** Dependencies flow inward. The domain layer has zero Android dependencies. The data layer depends on domain interfaces. The presentation layer depends on domain use cases.
+
+### Data Flow
+
+```
+User Action → ViewModel → UseCase → Repository → DAO → Room/SQLite
+                                                            │
+UI Update  ← StateFlow  ← Flow   ← Flow      ← Flow  ←────┘
+```
+
+- **Mutations** (add, update, delete): `suspend` functions returning `Result<T>`
+- **Queries** (get tasks, observe): `Flow<T>` for reactive updates
+- **UI State**: `StateFlow<UiState>` exposed by ViewModels
+
+## Domain Model
+
+### Core Entity
+
+```kotlin
+data class Task(
+    val id: Long = 0,
+    val title: String,
+    val description: String? = null,
+    val isCompleted: Boolean = false,
+    val createdAt: Long,    // epoch millis
+    val updatedAt: Long     // epoch millis
+)
+```
+
+### Repository Interface
+
+```kotlin
+interface TaskRepository {
+    fun getAllTasks(): Flow<List<Task>>
+    fun getIncompleteTasks(): Flow<List<Task>>
+    fun getTaskById(id: Long): Flow<Task?>
+    suspend fun addTask(task: Task): Result<Long>
+    suspend fun updateTask(task: Task): Result<Unit>
+    suspend fun deleteTask(task: Task): Result<Unit>
+}
+```
+
+### Use Cases
+
+| Use Case | Responsibility |
+|----------|----------------|
+| `GetTasksUseCase` | Observes all tasks via repository |
+| `GetRandomTaskUseCase` | Selects random incomplete task, returns `null` if none |
+| `AddTaskUseCase` | Validates title not blank, delegates to repository |
+| `UpdateTaskUseCase` | Validates title, updates timestamp, delegates |
+| `CompleteTaskUseCase` | Marks task completed, updates timestamp |
+| `DeleteTaskUseCase` | Passes through to repository |
+
+All use cases use constructor injection and `operator fun invoke()` for clean call-site syntax.
+
+## Data Access Layer
+
+### Room Entity
+
+```kotlin
+@Entity(tableName = "tasks")
+data class TaskEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "title") val title: String,
+    @ColumnInfo(name = "description") val description: String? = null,
+    @ColumnInfo(name = "is_completed") val isCompleted: Boolean = false,
+    @ColumnInfo(name = "created_at") val createdAt: Long,
+    @ColumnInfo(name = "updated_at") val updatedAt: Long
+)
+```
+
+### DAO
+
+- Queries return `Flow<List<TaskEntity>>` for reactive observation
+- Mutations are `suspend` functions
+- `getTaskByIdFlow()` provides Flow-based single-item observation
+- `getTaskById()` provides suspend-based single-shot lookup
+- All list queries ordered by `created_at DESC`
+
+### Mappers
+
+Extension functions in `TaskMappers.kt` handle bidirectional conversion:
+- `TaskEntity.toDomain(): Task`
+- `Task.toEntity(): TaskEntity`
+
+No business logic — purely structural transformation.
+
+### Database
+
+- Single `AppDatabase` extending `RoomDatabase`
+- Database name: `random_task_db`
+- Version 1, schema export disabled (development phase)
+
+## Dependency Injection
+
+Three Hilt modules in the `di/` package:
+
+| Module | Scope | Provides |
+|--------|-------|----------|
+| `DatabaseModule` | `@Singleton` | `AppDatabase`, `TaskDao` |
+| `RepositoryModule` | `@Singleton` | `TaskRepository` (binds `TaskRepositoryImpl`) |
+| `CoroutineModule` | `@Singleton` | Named dispatchers: `@Named("IO")`, `@Named("Default")`, `@Named("Main")` |
+
+Named dispatchers enable testability — ViewModels inject dispatchers rather than hardcoding `Dispatchers.IO`.
+
+## Presentation Layer
+
+### Navigation
+
+- `Screen` sealed class defines type-safe routes
+- Three destinations: `TaskList` (start), `RandomTask`, `EditTask/{taskId}`
+- Single `NavGraph` composable wires all routes
+- Dynamic route parameter support via `navArgument`
+
+### Screens
+
+| Screen | ViewModel | State |
+|--------|-----------|-------|
+| `TaskListScreen` | `TaskListViewModel` | `TaskListUiState` (tasks, loading, error, dialog visibility) |
+| `RandomTaskScreen` | `RandomTaskViewModel` | `RandomTaskUiState` (current task, loading, error, no-tasks, completed) |
+| `TaskEditorScreen` | `TaskEditorViewModel` | `TaskEditorUiState` (title, loading, saved, error) |
+
+### UI Models
+
+- `TaskUiModel` — Display-ready task with formatted timestamps (`"MMM d, yyyy h:mm a"`)
+- `Task.toUiModel()` extension mapper
+- `SampleData` object provides preview data for Compose previews
+
+### Theming
+
+- Material3 with dynamic color support (Android 12+)
+- Custom teal-based palette for light and dark schemes
+- Custom typography scale
+- Applied globally via `RandomTaskTheme` composable
+
+## Entry Points
+
+- `RandomTaskApplication` — `@HiltAndroidApp` application class
+- `MainActivity` — Single `@AndroidEntryPoint` activity, enables edge-to-edge, hosts `NavGraph`
+
+## Project Structure
+
+```
+app/src/main/java/com/nshaddox/randomtask/
+├── MainActivity.kt
+├── RandomTaskApplication.kt
+├── data/
+│   ├── local/
+│   │   ├── AppDatabase.kt
+│   │   ├── TaskDao.kt
+│   │   └── TaskEntity.kt
+│   └── repository/
+│       ├── TaskRepositoryImpl.kt
+│       └── TaskMappers.kt
+├── di/
+│   ├── DatabaseModule.kt
+│   ├── RepositoryModule.kt
+│   └── CoroutineModule.kt
+├── domain/
+│   ├── model/
+│   │   └── Task.kt
+│   ├── repository/
+│   │   └── TaskRepository.kt
+│   └── usecase/
+│       ├── GetTasksUseCase.kt
+│       ├── GetRandomTaskUseCase.kt
+│       ├── AddTaskUseCase.kt
+│       ├── UpdateTaskUseCase.kt
+│       ├── CompleteTaskUseCase.kt
+│       └── DeleteTaskUseCase.kt
+└── ui/
+    ├── navigation/
+    │   ├── NavRoutes.kt
+    │   └── NavGraph.kt
+    ├── screens/
+    │   ├── tasklist/
+    │   │   ├── TaskListScreen.kt
+    │   │   ├── TaskListViewModel.kt
+    │   │   ├── TaskListUiState.kt
+    │   │   ├── TaskUiModel.kt
+    │   │   ├── TaskUiMappers.kt
+    │   │   └── AddTaskDialog.kt
+    │   ├── randomtask/
+    │   │   ├── RandomTaskScreen.kt
+    │   │   ├── RandomTaskViewModel.kt
+    │   │   └── RandomTaskUiState.kt
+    │   └── taskeditor/
+    │       ├── TaskEditorScreen.kt
+    │       └── TaskEditorViewModel.kt
+    ├── preview/
+    │   └── MockData.kt
+    └── theme/
+        ├── Color.kt
+        ├── Theme.kt
+        └── Type.kt
+```
+
+## Key Architectural Decisions
+
+1. **MVVM over MVI** — Simpler for this app's scope; ViewModels expose `StateFlow<UiState>`
+2. **Use cases as thin wrappers** — Validation lives in use cases, not ViewModels or repositories
+3. **Result type for mutations** — All suspend operations return `Result<T>` for explicit error handling
+4. **Named dispatchers** — Injected via Hilt for testability instead of hardcoded `Dispatchers.*`
+5. **Extension function mappers** — Clean layer transformation without mapper classes
+6. **Flow-based queries** — Room's reactive queries propagate database changes automatically to the UI
+7. **Single Activity** — All navigation handled by Compose Navigation within one Activity
+8. **No DTOs** — Direct entity-to-domain mapping; UI models are separate for display formatting only
+
+## Testing Architecture
+
+For detailed testing patterns and strategies, see the **[Testing Guide](TESTING.md)**.
+
+### Test Pyramid
+
+- **Unit Tests** — Use cases, ViewModels, mappers (JUnit 4, MockK, Turbine, coroutines-test)
+- **Integration Tests** — Room DAO operations (Hilt testing, Room testing)
+- **UI Tests** — Compose component tests (Compose UI testing, Espresso)
+
+### Test Data
+
+- `FakeTaskRepository` — In-memory test implementation using `MutableStateFlow`
+- `SampleData` object — Pre-fabricated task instances for Compose previews

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,250 @@
+# Development Guide
+
+This guide covers development setup, workflow, and contribution guidelines for the Random Task application.
+
+## Prerequisites
+
+- **Android Studio** (latest stable) or IntelliJ IDEA with Android plugin
+- **JDK 17** or later
+- **Android SDK** with API 35 installed
+- **Git** for version control
+- **Android device or emulator** running API 24+ for testing
+
+## Quick Start
+
+```bash
+git clone <repository-url>
+cd RandomTask
+
+# Install pre-commit hooks
+./gradlew installGitHooks
+
+# Build the app
+./gradlew assembleDebug
+
+# Run unit tests
+./gradlew test
+
+# Install on connected device/emulator
+./gradlew installDebug
+```
+
+## Build Commands
+
+```bash
+# Debug build
+./gradlew assembleDebug
+
+# Release build
+./gradlew assembleRelease
+
+# Clean build
+./gradlew clean assembleDebug
+
+# Run all unit tests
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests com.nshaddox.randomtask.domain.usecase.AddTaskUseCaseTest
+
+# Run tests matching a pattern
+./gradlew test --tests "*ViewModelTest"
+
+# Run instrumented tests (requires device/emulator)
+./gradlew connectedAndroidTest
+
+# Run Android lint
+./gradlew lintDebug
+
+# View all available Gradle tasks
+./gradlew tasks
+```
+
+## Development Workflow
+
+### Feature Development Process
+
+1. **Create a feature branch** from `main`
+2. **Understand requirements** — Read the relevant GitHub issue
+3. **Write tests first** — Follow the test patterns in [Testing Guide](TESTING.md)
+4. **Implement the feature** — Make tests pass with clean code
+5. **Run all checks** — `./gradlew lintDebug testDebugUnitTest`
+6. **Commit** — Pre-commit hooks validate automatically
+7. **Open a pull request** against `main`
+
+### Branch Naming
+
+Follow the convention: `issue-{number}-{short-description}`
+
+Examples:
+- `issue-201-priority-enum`
+- `issue-204-db-migration`
+- `issue-216-list-viewmodel`
+
+### Commit Messages
+
+Use descriptive commit messages that explain the *why*, not just the *what*:
+
+```
+feat(domain): add Priority enum and mapper support
+
+Add Priority enum (LOW, MEDIUM, HIGH) to the domain model with
+bidirectional mapper support in TaskMappers.kt. Default value
+is MEDIUM for backwards compatibility.
+
+Closes #201
+```
+
+Prefix conventions:
+- `feat` — New feature
+- `fix` — Bug fix
+- `refactor` — Code restructuring without behavior change
+- `test` — Adding or updating tests
+- `docs` — Documentation changes
+- `chore` — Build, CI, or tooling changes
+
+### Quality Gates
+
+#### Before Commit
+
+- [ ] All unit tests pass (`./gradlew test`)
+- [ ] Lint checks pass (`./gradlew lintDebug`)
+- [ ] Pre-commit hook passes (runs both automatically)
+- [ ] No hardcoded strings in UI (use string resources)
+
+#### Before Merge
+
+- [ ] PR reviewed
+- [ ] CI pipeline passes
+- [ ] No unresolved review comments
+- [ ] Documentation updated if needed
+
+## Project Structure
+
+```
+RandomTask/
+├── app/
+│   ├── build.gradle.kts          # App module build config
+│   └── src/
+│       ├── main/
+│       │   ├── AndroidManifest.xml
+│       │   └── java/com/nshaddox/randomtask/
+│       │       ├── MainActivity.kt
+│       │       ├── RandomTaskApplication.kt
+│       │       ├── data/           # Room entities, DAO, repository impl, mappers
+│       │       ├── di/             # Hilt modules
+│       │       ├── domain/         # Task model, repository interface, use cases
+│       │       └── ui/             # Screens, ViewModels, navigation, theme
+│       ├── test/                   # Unit tests (JUnit 4, MockK, Turbine)
+│       └── androidTest/            # Instrumented tests (Hilt, Room, Compose)
+├── build.gradle.kts               # Root build config with plugins
+├── gradle/libs.versions.toml      # Version catalog
+├── git-hooks/                     # Pre-commit hook scripts
+├── docs/                          # Project documentation
+├── the-idea/                      # Planning documents and roadmap
+└── CLAUDE.md                      # AI agent guidance
+```
+
+## IDE Setup
+
+### Android Studio
+
+1. **Open project**: `File → Open` and select the `RandomTask/` root directory
+2. **Sync Gradle**: Android Studio will auto-sync; click "Sync Now" if prompted
+3. **Run configuration**: `app` run configuration is created automatically
+4. **Emulator**: Create an AVD with API 24+ via `Tools → Device Manager`
+
+### Useful IDE Settings
+
+- **Enable auto-import**: `Settings → Editor → General → Auto Import → Optimize imports on the fly`
+- **Format on save**: `Settings → Tools → Actions on Save → Reformat code`
+- **KSP generated sources**: Should be auto-detected; if not, mark `build/generated/ksp` as generated sources root
+
+## Dependency Management
+
+All dependencies are managed via the Gradle version catalog at `gradle/libs.versions.toml`:
+
+```toml
+[versions]
+kotlin = "2.0.21"
+composeBom = "2026.02.00"
+hilt = "2.51.1"
+room = "2.8.4"
+# ... etc
+```
+
+To add a new dependency:
+1. Add the version to `[versions]`
+2. Add the library to `[libraries]`
+3. Reference it in `build.gradle.kts` as `libs.your.library`
+
+## Database
+
+### Room Database
+
+- Database name: `random_task_db`
+- Located in app's internal storage
+- Current version: 1
+
+### Schema Changes
+
+When modifying entities:
+1. Increment `@Database(version = N)` in `AppDatabase`
+2. Add a `Migration(N-1, N)` with the appropriate `ALTER TABLE` SQL
+3. Register the migration in `DatabaseModule` via `.addMigrations()`
+4. Test the migration with Room's migration testing utilities
+
+### Inspecting the Database
+
+Use Android Studio's **Database Inspector** (`View → Tool Windows → App Inspection`) to browse the live database on a running device/emulator.
+
+## Hilt Dependency Injection
+
+### Module Organization
+
+| Module | What it provides |
+|--------|------------------|
+| `DatabaseModule` | `AppDatabase`, `TaskDao` |
+| `RepositoryModule` | `TaskRepository` (binds impl) |
+| `CoroutineModule` | Named dispatchers (`IO`, `Default`, `Main`) |
+
+### Adding a New Dependency
+
+1. Create or update the appropriate Hilt `@Module`
+2. Use `@Provides` for concrete instances or `@Binds` for interface-to-impl bindings
+3. Scope with `@Singleton` for app-wide singletons
+4. Inject via constructor injection (prefer over field injection)
+
+## Troubleshooting
+
+### Build Fails
+
+```bash
+# Clean and rebuild
+./gradlew clean assembleDebug
+
+# Invalidate caches in Android Studio
+File → Invalidate Caches → Invalidate and Restart
+```
+
+### KSP/Hilt Errors
+
+- Ensure all `@HiltViewModel` classes have `@Inject constructor`
+- Check that `@AndroidEntryPoint` is on `MainActivity`
+- Run `./gradlew clean` to clear stale generated code
+
+### Room Schema Errors
+
+- Entity changes require a migration or database version bump
+- Check that `@ColumnInfo` names match your SQL in migrations
+- Use `fallbackToDestructiveMigration()` only during development (never in production)
+
+### Test Failures
+
+- Run with `--info` for detailed output: `./gradlew test --info`
+- Check that `Dispatchers.setMain()` is called in `@Before` for ViewModel tests
+- Ensure Turbine's `test {}` block awaits all expected emissions
+
+### Pre-commit Hook Issues
+
+See the **[Pre-commit Guide](PRECOMMIT.md)** for hook troubleshooting.

--- a/docs/PRECOMMIT.md
+++ b/docs/PRECOMMIT.md
@@ -1,0 +1,210 @@
+# Pre-commit Hooks Guide
+
+This guide covers the pre-commit hook configuration, usage, and troubleshooting for the Random Task application.
+
+## Overview
+
+Pre-commit hooks run automated checks before each commit to ensure code quality. They catch lint violations and test failures early, before changes reach the repository.
+
+## Installation
+
+### Quick Setup
+
+```bash
+./gradlew installGitHooks
+```
+
+This copies the hook script from `git-hooks/pre-commit` to `.git/hooks/pre-commit` and sets executable permissions.
+
+### Manual Installation
+
+```bash
+cp git-hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+### Verification
+
+```bash
+# Check that the hook is installed
+ls -la .git/hooks/pre-commit
+
+# Test the hook manually
+.git/hooks/pre-commit
+```
+
+## What the Hook Does
+
+The pre-commit hook runs two checks sequentially:
+
+```bash
+#!/bin/bash
+set -e
+
+echo "Running pre-commit checks..."
+./gradlew lintDebug --quiet
+./gradlew testDebugUnitTest --quiet
+echo "All checks passed! Proceeding with commit."
+```
+
+### 1. Android Lint (`lintDebug`)
+
+- Checks for Android-specific issues (unused resources, accessibility, API compatibility)
+- Validates XML layouts and Compose code
+- Reports are generated at `app/build/reports/lint-results-debug.html`
+
+### 2. Unit Tests (`testDebugUnitTest`)
+
+- Runs all unit tests in `app/src/test/`
+- Covers use cases, ViewModels, mappers, and state classes
+- Reports are generated at `app/build/reports/tests/testDebugUnitTest/index.html`
+
+If either check fails, the commit is aborted. Fix the issues and try again.
+
+## Usage
+
+### Normal Workflow
+
+1. Make your changes
+2. Stage files: `git add <files>`
+3. Commit: `git commit -m "your message"`
+4. Hook runs automatically — if checks pass, commit proceeds
+5. If checks fail, fix the issues, re-stage, and commit again
+
+### Skipping Hooks
+
+```bash
+# Skip all hooks (use sparingly)
+git commit --no-verify -m "your message"
+```
+
+Use `--no-verify` only when:
+- You're committing documentation-only changes
+- You're in the middle of a rebase/merge and have already verified tests
+- The hook is failing due to an environment issue, not a code issue
+
+**Never skip hooks to avoid fixing lint or test failures.**
+
+### Running Checks Manually
+
+You can run the same checks the hook runs at any time:
+
+```bash
+# Run both checks (same as the hook)
+./gradlew lintDebug testDebugUnitTest
+
+# Run just lint
+./gradlew lintDebug
+
+# Run just tests
+./gradlew testDebugUnitTest
+
+# Run with verbose output for debugging
+./gradlew lintDebug testDebugUnitTest --info
+```
+
+## Hook Configuration
+
+### Source File
+
+The hook script lives at `git-hooks/pre-commit` and is version-controlled. Any changes to the hook should be made to this file, not directly to `.git/hooks/pre-commit`.
+
+### Gradle Task
+
+The `installGitHooks` task is defined in the root `build.gradle.kts`:
+
+```kotlin
+tasks.register<Copy>("installGitHooks") {
+    from("git-hooks/pre-commit")
+    into(".git/hooks")
+    filePermissions { unix("rwxr-xr-x") }
+}
+```
+
+## Troubleshooting
+
+### Hook Not Running
+
+```bash
+# Verify the hook exists and is executable
+ls -la .git/hooks/pre-commit
+
+# Reinstall if missing
+./gradlew installGitHooks
+
+# Check file permissions (should be -rwxr-xr-x)
+chmod +x .git/hooks/pre-commit
+```
+
+### Lint Failures
+
+```bash
+# Run lint with full output to see the issue
+./gradlew lintDebug
+
+# Open the lint report for details
+open app/build/reports/lint-results-debug.html
+```
+
+Common lint issues:
+- Missing content descriptions on images/icons
+- Hardcoded strings (use `@string/` resources)
+- Unused resources or imports
+- API compatibility issues with min SDK 24
+
+### Test Failures
+
+```bash
+# Run tests with info-level logging
+./gradlew testDebugUnitTest --info
+
+# Run a specific failing test for focused debugging
+./gradlew test --tests "com.nshaddox.randomtask.domain.usecase.AddTaskUseCaseTest"
+
+# Open the test report
+open app/build/reports/tests/testDebugUnitTest/index.html
+```
+
+Common test issues:
+- Missing `Dispatchers.setMain()` in ViewModel tests
+- Turbine `.test {}` block not awaiting all emissions
+- Stale generated code — run `./gradlew clean` first
+
+### Hook Is Slow
+
+The hook runs lint and all unit tests, which can take 30-60 seconds. To speed things up:
+
+- Ensure Gradle daemon is running (`./gradlew --status`)
+- Use Gradle build cache (enabled by default)
+- Close other resource-heavy applications during commits
+
+### Hook Fails After Merge/Rebase
+
+If the hook fails after pulling changes:
+
+```bash
+# Clean and rebuild to clear stale state
+./gradlew clean
+
+# Then try committing again
+git add .
+git commit -m "your message"
+```
+
+## CI Integration
+
+The same checks run in the GitHub Actions CI pipeline (`.github/workflows/android-ci.yml`):
+
+1. `lintDebug` — Same lint check as the hook
+2. `testDebugUnitTest` — Same unit tests as the hook
+3. `assembleDebug` — Additional build verification
+
+This means the hook catches issues locally before they reach CI, providing faster feedback.
+
+## Best Practices
+
+1. **Never skip hooks to avoid fixing issues** — The hook exists to protect code quality
+2. **Run checks manually before large commits** — Don't wait for the hook if you're unsure
+3. **Keep the hook fast** — If new checks are added, balance thoroughness with speed
+4. **Fix hook failures immediately** — Don't accumulate issues to fix later
+5. **Update the hook via `git-hooks/pre-commit`** — Never edit `.git/hooks/` directly since it's not version-controlled

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,386 @@
+# Testing Guide
+
+This guide covers the testing strategy, patterns, and best practices for the Random Task application.
+
+## Overview
+
+Random Task uses a layered testing approach following the test pyramid principle. Tests validate behavior across domain logic, data access, ViewModels, and UI components.
+
+## Test Structure
+
+```
+app/src/test/java/com/nshaddox/randomtask/
+├── domain/usecase/
+│   ├── FakeTaskRepository.kt          # In-memory test repository
+│   ├── AddTaskUseCaseTest.kt
+│   ├── UpdateTaskUseCaseTest.kt
+│   ├── CompleteTaskUseCaseTest.kt
+│   ├── DeleteTaskUseCaseTest.kt
+│   ├── GetTasksUseCaseTest.kt
+│   └── GetRandomTaskUseCaseTest.kt
+├── data/repository/
+│   └── TaskMappersTest.kt
+└── ui/screens/
+    ├── tasklist/
+    │   ├── TaskListViewModelTest.kt
+    │   ├── TaskListUiStateTest.kt
+    │   └── TaskUiMappersTest.kt
+    ├── randomtask/
+    │   ├── RandomTaskViewModelTest.kt
+    │   └── RandomTaskUiStateTest.kt
+    └── taskeditor/
+        └── TaskEditorViewModelTest.kt
+
+app/src/androidTest/java/com/nshaddox/randomtask/
+├── ExampleInstrumentedTest.kt
+└── HiltTestRunner.kt
+```
+
+## Test Pyramid
+
+```
+        ┌──────────────┐
+        │   UI Tests   │  Compose UI Testing, Espresso
+        │   (few)      │  Full component rendering
+        ├──────────────┤
+        │ Integration  │  Room DAO tests, Hilt testing
+        │  (moderate)  │  Real database operations
+        ├──────────────┤
+        │  Unit Tests  │  JUnit 4, MockK, Turbine
+        │   (many)     │  Use cases, ViewModels, mappers
+        └──────────────┘
+```
+
+- **Unit tests** are fast, isolated, and make up the bulk of the suite
+- **Integration tests** verify Room queries and Hilt wiring against real databases
+- **UI tests** validate Compose component behavior and user interactions
+
+## Testing Frameworks and Tools
+
+| Tool | Purpose | Dependency |
+|------|---------|------------|
+| **JUnit 4** | Test runner and assertions | `junit:junit:4.13.2` |
+| **MockK** | Kotlin-first mocking | `io.mockk:mockk:1.13.17` |
+| **Turbine** | Flow testing utilities | `app.cash.turbine:turbine:1.2.1` |
+| **Coroutines Test** | Test dispatcher and `runTest` | `kotlinx-coroutines-test:1.10.2` |
+| **Hilt Testing** | DI in instrumented tests | `hilt-android-testing:2.51.1` |
+| **Room Testing** | Migration testing | `room-testing:2.8.4` |
+| **Compose UI Testing** | Compose component tests | `ui-test-junit4` (via BOM) |
+| **Espresso** | Android UI assertions | `espresso-core:3.6.1` |
+
+## Unit Testing Patterns
+
+### Use Case Tests
+
+Use cases are tested with `FakeTaskRepository`, an in-memory implementation backed by `MutableStateFlow`:
+
+```kotlin
+class AddTaskUseCaseTest {
+    private lateinit var fakeRepository: FakeTaskRepository
+    private lateinit var addTaskUseCase: AddTaskUseCase
+
+    @Before
+    fun setup() {
+        fakeRepository = FakeTaskRepository()
+        addTaskUseCase = AddTaskUseCase(fakeRepository)
+    }
+
+    @Test
+    fun `invoke with valid title returns success with task id`() = runTest {
+        val result = addTaskUseCase("Buy groceries", "Milk and eggs")
+        assertTrue(result.isSuccess)
+        assertNotNull(result.getOrNull())
+    }
+
+    @Test
+    fun `invoke with blank title returns failure`() = runTest {
+        val result = addTaskUseCase("  ", null)
+        assertTrue(result.isFailure)
+    }
+}
+```
+
+**Key patterns:**
+- `FakeTaskRepository` over mocks for domain tests — simulates real behavior
+- `runTest` from coroutines-test for suspend function testing
+- Test both success and failure paths
+- Test edge cases (blank input, empty lists, null values)
+
+### ViewModel Tests
+
+ViewModels require dispatcher setup for coroutine testing:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class TaskListViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var viewModel: TaskListViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        // ... create ViewModel with test dependencies
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has loading true`() = runTest(testDispatcher) {
+        viewModel.uiState.test {
+            val state = awaitItem()
+            assertTrue(state.isLoading)
+        }
+    }
+
+    @Test
+    fun `addTask with valid title updates task list`() = runTest(testDispatcher) {
+        viewModel.uiState.test {
+            skipItems(1) // skip initial state
+            viewModel.addTask("New task", null)
+            val state = awaitItem()
+            assertTrue(state.tasks.any { it.title == "New task" })
+        }
+    }
+}
+```
+
+**Key patterns:**
+- `StandardTestDispatcher` for controlled async execution
+- `Dispatchers.setMain()` / `resetMain()` in `@Before` / `@After`
+- Turbine's `.test {}` block for `StateFlow` assertions
+- `skipItems(n)` to skip initial state emissions
+- `awaitItem()` to get next emission
+
+### Mapper Tests
+
+```kotlin
+class TaskMappersTest {
+    @Test
+    fun `toDomain maps all fields correctly`() {
+        val entity = TaskEntity(
+            id = 1, title = "Test", description = "Desc",
+            isCompleted = false, createdAt = 1000L, updatedAt = 2000L
+        )
+        val task = entity.toDomain()
+        assertEquals("Test", task.title)
+        assertEquals(1000L, task.createdAt)
+    }
+
+    @Test
+    fun `toEntity maps all fields correctly`() {
+        val task = Task(
+            id = 1, title = "Test", description = null,
+            isCompleted = true, createdAt = 1000L, updatedAt = 2000L
+        )
+        val entity = task.toEntity()
+        assertEquals("Test", entity.title)
+        assertNull(entity.description)
+    }
+}
+```
+
+### UiState Tests
+
+Verify default state values:
+
+```kotlin
+class TaskListUiStateTest {
+    @Test
+    fun `default state has empty task list and loading true`() {
+        val state = TaskListUiState()
+        assertTrue(state.tasks.isEmpty())
+        assertTrue(state.isLoading)
+        assertNull(state.errorMessage)
+    }
+}
+```
+
+## Integration Testing
+
+### Hilt Test Runner
+
+A custom `HiltTestRunner` is configured for instrumented tests:
+
+```kotlin
+class HiltTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}
+```
+
+This is registered in `app/build.gradle.kts`:
+```kotlin
+testInstrumentationRunner = "com.nshaddox.randomtask.HiltTestRunner"
+```
+
+### Room DAO Tests
+
+When writing DAO tests, use `@HiltAndroidTest` with an in-memory database:
+
+```kotlin
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class TaskDaoTest {
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    private lateinit var database: AppDatabase
+    private lateinit var dao: TaskDao
+
+    @Before
+    fun setup() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java
+        ).allowMainThreadQueries().build()
+        dao = database.taskDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+}
+```
+
+### Migration Tests
+
+When adding database migrations, test them with Room's `MigrationTestHelper`:
+
+```kotlin
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java
+    )
+
+    @Test
+    fun migrate1To2() {
+        // Create version 1 database
+        helper.createDatabase(TEST_DB, 1).apply {
+            execSQL("INSERT INTO tasks (title, is_completed, created_at, updated_at) VALUES ('Test', 0, 1000, 2000)")
+            close()
+        }
+
+        // Run migration and validate
+        val db = helper.runMigrationsAndValidate(TEST_DB, 2, true, MIGRATION_1_2)
+        // ... verify data survived migration
+    }
+}
+```
+
+## Running Tests
+
+### Command Line
+
+```bash
+# All unit tests
+./gradlew test
+
+# Specific test class
+./gradlew test --tests com.nshaddox.randomtask.domain.usecase.AddTaskUseCaseTest
+
+# Tests matching a pattern
+./gradlew test --tests "*ViewModelTest"
+
+# With detailed output
+./gradlew test --info
+
+# Instrumented tests (requires device/emulator)
+./gradlew connectedAndroidTest
+
+# Both lint and tests (same as pre-commit hook)
+./gradlew lintDebug testDebugUnitTest
+```
+
+### Android Studio
+
+- **Run single test**: Click the green play icon next to a test method
+- **Run test class**: Click the green play icon next to the class declaration
+- **Run all tests**: Right-click the `test/` directory → `Run Tests`
+- **Debug tests**: Use breakpoints and the debug runner
+
+### Test Reports
+
+After running tests, reports are generated at:
+- **Unit tests**: `app/build/reports/tests/testDebugUnitTest/index.html`
+- **Test results**: `app/build/test-results/testDebugUnitTest/`
+
+## Test Data
+
+### FakeTaskRepository
+
+The test suite uses a `FakeTaskRepository` backed by `MutableStateFlow<List<Task>>` for unit tests:
+
+- Simulates real repository behavior without Room
+- Supports all `TaskRepository` interface methods
+- Auto-generates IDs for inserted tasks
+- Emits updates reactively via Flow
+
+### SampleData (Previews)
+
+`MockData.kt` provides `SampleData` object with pre-fabricated tasks for Compose previews:
+- `sampleTask` — A basic task
+- `sampleTasks` — A list of tasks in various states
+- `emptyTaskList` — Empty list for empty-state previews
+- `sampleTaskWithDescription` — Task with description populated
+
+## Best Practices
+
+### Test Organization
+
+- **Mirror source structure**: Test files live in the same package path as the code they test
+- **One test class per source class**: `AddTaskUseCase` → `AddTaskUseCaseTest`
+- **Descriptive test names**: Use backtick syntax that reads as a specification:
+  ```kotlin
+  @Test
+  fun `addTask with blank title returns failure`() { ... }
+  ```
+
+### Test Independence
+
+- Each test must be able to run in isolation
+- Use `@Before` to create fresh instances — never share mutable state between tests
+- Use `@After` to clean up dispatchers and resources
+
+### Assertion Patterns
+
+- Use Kotlin's built-in `assertTrue`, `assertEquals`, `assertNull` for simple assertions
+- Use Turbine's `awaitItem()` for Flow emissions — avoid `first()` which can miss updates
+- Test `Result<T>` with `.isSuccess` / `.isFailure` and `.getOrNull()` / `.exceptionOrNull()`
+
+### What to Test
+
+| Layer | What to test | What NOT to test |
+|-------|-------------|-----------------|
+| **Use Cases** | Validation logic, error handling, delegation | Repository internals |
+| **ViewModels** | State transitions, user action handling, error propagation | Compose UI rendering |
+| **Mappers** | All field mappings, null handling, default values | — |
+| **DAO** | Query correctness, insert/update/delete behavior | Room framework internals |
+| **UI** | User interactions, state rendering, navigation triggers | ViewModel logic (tested separately) |
+
+### Coroutine Testing Checklist
+
+- [ ] `StandardTestDispatcher` created and used consistently
+- [ ] `Dispatchers.setMain(testDispatcher)` in `@Before`
+- [ ] `Dispatchers.resetMain()` in `@After`
+- [ ] `runTest(testDispatcher)` wraps test body
+- [ ] Turbine `.test {}` used for Flow assertions
+- [ ] `testDispatcher.scheduler.advanceUntilIdle()` called when needed
+
+## CI Integration
+
+The GitHub Actions workflow (`.github/workflows/android-ci.yml`) runs:
+1. `lintDebug` — Android lint checks
+2. `testDebugUnitTest` — All unit tests
+3. `assembleDebug` — Debug build
+
+Test results and lint reports are uploaded as workflow artifacts with 7-day retention.
+
+The pre-commit hook runs the same `lintDebug` and `testDebugUnitTest` checks locally before each commit. See the **[Pre-commit Guide](PRECOMMIT.md)** for details.


### PR DESCRIPTION
## Summary
- Add comprehensive development docs (ARCHITECTURE.md, DEVELOPMENT.md, TESTING.md, PRECOMMIT.md) based on FORGE repo patterns
- Update CLAUDE.md to reflect actual project state (v1.0 complete, not "initial setup") with on-demand doc references instead of auto-loading
- Add GITHUB_ISSUES_V1_5.md for dev tooling milestone (ktlint, detekt, issue templates, spacing system)

## Test plan
- [ ] Verify doc links/references are accurate to current codebase
- [ ] Confirm CLAUDE.md no longer uses `@` notation for doc references
- [ ] Review docs for completeness against actual project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)