### PR TITLE
chore: block direct commits to main in pre-commit hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,8 +1,17 @@
 #!/bin/bash
 # Pre-commit hook for Android project
-# Runs lint and unit tests before allowing commit
+# Blocks direct commits to main and runs lint + unit tests
 
 set -e
+
+# Block direct commits to main
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+if [ "$BRANCH" = "main" ]; then
+    echo "❌ ERROR: Direct commits to main are not allowed."
+    echo "   Please create a feature branch first:"
+    echo "   git checkout -b your-branch-name"
+    exit 1
+fi
 
 echo "🔍 Running pre-commit checks..."
 


### PR DESCRIPTION
## Summary
- Add branch check to pre-commit hook that blocks direct commits to `main`
- Enforces feature-branch workflow — all changes must go through PRs
- Detached HEAD states (CI) pass gracefully
- Existing lint and test checks unchanged

## Test plan
- [ ] Verify committing on a feature branch still works (lint + tests run)
- [ ] Verify committing on `main` is blocked with clear error message
- [ ] Verify `--no-verify` can bypass if absolutely needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)