### PR TITLE
feat(github): add bug report and feature request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug
+title: "[Bug] "
+labels: bug
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## Actual Behavior
+
+What actually happened?
+
+## Device / OS Information
+
+- **Manufacturer / Model**: (e.g., Google Pixel 8)
+- **Android Version**: (e.g., Android 14, API 34)
+- **App Version**: (e.g., 1.0.0)
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem. (optional)

--- a/.github/ISSUE_TEMPLATE/02-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest a feature
+title: "[Feature] "
+labels: enhancement
+---
+
+## Description
+
+A clear and concise description of the feature you are proposing.
+
+## Use Case / Problem
+
+What problem does this feature solve? Who benefits from it and in what situation?
+
+## Proposed Solution
+
+Describe how you envision the feature working.
+
+## Alternatives Considered
+
+Have you considered any alternative approaches or workarounds? If so, describe them.
+
+## Additional Context
+
+Add any other context, screenshots, or links that might help explain the request. (optional)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/01-bug_report.md` — structured bug report template with frontmatter auto-populating the `[Bug] ` title prefix and `bug` label, plus six sections: Description, Steps to Reproduce, Expected Behavior, Actual Behavior, Device / OS Information, Screenshots
- Add `.github/ISSUE_TEMPLATE/02-feature_request.md` — feature request template with `[Feature] ` title prefix and `enhancement` label, plus five sections: Description, Use Case / Problem, Proposed Solution, Alternatives Considered, Additional Context
- Add `.github/ISSUE_TEMPLATE/config.yml` — enables the issue chooser UI while keeping blank issues available (`blank_issues_enabled: true`)

## Test plan

- [ ] Merge to `main` and open the GitHub repo
- [ ] Click "New Issue" — confirm both templates appear in the chooser with correct names and descriptions
- [ ] Open the bug report template — confirm title is pre-filled with `[Bug] ` and the `bug` label is applied
- [ ] Open the feature request template — confirm title is pre-filled with `[Feature] ` and the `enhancement` label is applied
- [ ] Confirm "Open a blank issue" option remains available in the chooser

Closes #73
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)