### PR TITLE
feat(205): update AddTaskUseCase to accept v2 fields

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/AddTaskUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/AddTaskUseCase.kt
@@ -1,5 +1,6 @@
 package com.nshaddox.randomtask.domain.usecase
 
+import com.nshaddox.randomtask.domain.model.Priority
 import com.nshaddox.randomtask.domain.model.Task
 import com.nshaddox.randomtask.domain.repository.TaskRepository
 import javax.inject.Inject
@@ -9,10 +10,27 @@ class AddTaskUseCase
     constructor(
         private val repository: TaskRepository,
     ) {
-        suspend operator fun invoke(task: Task): Result<Long> {
-            if (task.title.isBlank()) {
+        suspend operator fun invoke(
+            title: String,
+            description: String? = null,
+            priority: Priority = Priority.MEDIUM,
+            dueDate: Long? = null,
+            category: String? = null,
+        ): Result<Long> {
+            if (title.isBlank()) {
                 return Result.failure(IllegalArgumentException("Task title cannot be blank"))
             }
+            val now = System.currentTimeMillis()
+            val task =
+                Task(
+                    title = title,
+                    description = description,
+                    priority = priority,
+                    dueDate = dueDate,
+                    category = category,
+                    createdAt = now,
+                    updatedAt = now,
+                )
             return repository.addTask(task)
         }
     }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
@@ -44,10 +44,8 @@ class TaskListViewModel
             title: String,
             description: String? = null,
         ) {
-            val now = System.currentTimeMillis()
-            val task = Task(title = title, description = description, createdAt = now, updatedAt = now)
             viewModelScope.launch(ioDispatcher) {
-                addTaskUseCase(task)
+                addTaskUseCase(title = title, description = description)
                     .onFailure { error ->
                         _uiState.update { it.copy(errorMessage = error.message ?: "Failed to add task") }
                     }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/AddTaskUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/AddTaskUseCaseTest.kt
@@ -1,8 +1,10 @@
 package com.nshaddox.randomtask.domain.usecase
 
-import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.model.Priority
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -18,22 +20,54 @@ class AddTaskUseCaseTest {
     }
 
     @Test
-    fun `invoke with valid title returns success with id`() =
+    fun `invoke with title only stores task with MEDIUM priority null dueDate null category`() =
         runTest {
-            val task = Task(title = "Valid Task", createdAt = 1000L, updatedAt = 1000L)
+            addTaskUseCase(title = "Simple Task")
 
-            val result = addTaskUseCase(task)
+            val stored = repository.getAllTasksSnapshot().first()
+            assertEquals("Simple Task", stored.title)
+            assertNull(stored.description)
+            assertEquals(Priority.MEDIUM, stored.priority)
+            assertNull(stored.dueDate)
+            assertNull(stored.category)
+        }
 
-            assertTrue(result.isSuccess)
-            assertEquals(1L, result.getOrNull())
+    @Test
+    fun `invoke with all explicit params stores correct field values`() =
+        runTest {
+            addTaskUseCase(
+                title = "Full Task",
+                description = "A detailed description",
+                priority = Priority.LOW,
+                dueDate = 19900L,
+                category = "Work",
+            )
+
+            val stored = repository.getAllTasksSnapshot().first()
+            assertEquals("Full Task", stored.title)
+            assertEquals("A detailed description", stored.description)
+            assertEquals(Priority.LOW, stored.priority)
+            assertEquals(19900L, stored.dueDate)
+            assertEquals("Work", stored.category)
+        }
+
+    @Test
+    fun `invoke sets createdAt and updatedAt to current time`() =
+        runTest {
+            val before = System.currentTimeMillis()
+
+            addTaskUseCase(title = "Timed Task")
+
+            val stored = repository.getAllTasksSnapshot().first()
+            assertTrue(stored.createdAt >= before)
+            assertTrue(stored.updatedAt >= before)
+            assertEquals(stored.createdAt, stored.updatedAt)
         }
 
     @Test
     fun `invoke with blank title returns failure`() =
         runTest {
-            val task = Task(title = "   ", createdAt = 1000L, updatedAt = 1000L)
-
-            val result = addTaskUseCase(task)
+            val result = addTaskUseCase(title = "   ")
 
             assertTrue(result.isFailure)
             assertTrue(result.exceptionOrNull() is IllegalArgumentException)
@@ -42,11 +76,19 @@ class AddTaskUseCaseTest {
     @Test
     fun `invoke with empty title returns failure`() =
         runTest {
-            val task = Task(title = "", createdAt = 1000L, updatedAt = 1000L)
-
-            val result = addTaskUseCase(task)
+            val result = addTaskUseCase(title = "")
 
             assertTrue(result.isFailure)
             assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+        }
+
+    @Test
+    fun `invoke with valid title and description returns success with generated id`() =
+        runTest {
+            val result = addTaskUseCase(title = "Valid Task", description = "Some description")
+
+            assertTrue(result.isSuccess)
+            assertNotNull(result.getOrNull())
+            assertEquals(1L, result.getOrNull())
         }
 }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/FakeTaskRepository.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/FakeTaskRepository.kt
@@ -44,4 +44,6 @@ class FakeTaskRepository : TaskRepository {
         tasksFlow.update { tasks.toList() }
         return Result.success(Unit)
     }
+
+    fun getAllTasksSnapshot(): List<Task> = tasks.toList()
 }


### PR DESCRIPTION
## Summary

Changes AddTaskUseCase from accepting a Task object to accepting individual parameters (title, description, priority, dueDate, category) with sensible defaults. Task construction and timestamp assignment move into the use case, simplifying the caller API.

**Research**: `.rpi/03-add-task-v2-fields/research.md`
**Plan**: `.rpi/03-add-task-v2-fields/plan.md`
**Permanent Recap**: `docs/rpi/03-add-task-v2-fields.md`
**Upstream Dependencies**: #233 (feat/01-data-model-migration)

## RPI Metrics

| Metric | Value |
|--------|-------|
| FAR Score | 5.00 |
| FACTS Score | 4.53 |
| Tasks Planned | 3 |
| Tasks Completed | 3 |
| Deviations from Plan | 2 (dueDate as Long? matching Task model; ViewModel call site updated) |

## Key Changes

- **AddTaskUseCase**: Signature changed from `invoke(task: Task)` to `invoke(title, description?, priority, dueDate, category)` with defaults
- **Task construction**: Moved into use case body with `System.currentTimeMillis()` timestamps
- **TaskListViewModel**: Updated `addTask()` to use new parameter-based signature
- **6 new tests** replacing 3 old tests (default values, explicit params, blank title validation)
- **Room 2.7.0** downgrade (consistent with F1 — KSP compatibility fix)

## Checklist

- [x] Unit tests added (TDD: RED → GREEN → REFACTOR)
- [x] Lint passes
- [x] All tests pass
- [x] Domain layer has no Android imports
- [x] Existing validation preserved (blank title → failure)

## Related

- Issues: #205
- Depends on: #233 (feat/01-data-model-migration)
- Part of: RPI Orchestrate run 2026-03-14 (3 features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)