### PR TITLE
feat(04): new query use cases

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetCompletedTasksUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetCompletedTasksUseCase.kt
@@ -1,0 +1,16 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCompletedTasksUseCase
+    @Inject
+    constructor(
+        private val repository: TaskRepository,
+    ) {
+        operator fun invoke(): Flow<List<Task>> {
+            return repository.getCompletedTasks()
+        }
+    }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksByCategoryUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksByCategoryUseCase.kt
@@ -1,0 +1,16 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetTasksByCategoryUseCase
+    @Inject
+    constructor(
+        private val repository: TaskRepository,
+    ) {
+        operator fun invoke(category: String): Flow<List<Task>> {
+            return repository.getTasksByCategory(category)
+        }
+    }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksByPriorityUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/GetTasksByPriorityUseCase.kt
@@ -1,0 +1,17 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetTasksByPriorityUseCase
+    @Inject
+    constructor(
+        private val repository: TaskRepository,
+    ) {
+        operator fun invoke(priority: Priority): Flow<List<Task>> {
+            return repository.getTasksByPriority(priority)
+        }
+    }

--- a/app/src/main/java/com/nshaddox/randomtask/domain/usecase/SearchTasksUseCase.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/usecase/SearchTasksUseCase.kt
@@ -1,0 +1,18 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+
+class SearchTasksUseCase
+    @Inject
+    constructor(
+        private val repository: TaskRepository,
+    ) {
+        operator fun invoke(query: String): Flow<List<Task>> {
+            if (query.isBlank()) return flowOf(emptyList())
+            return repository.searchTasks(query.trim())
+        }
+    }

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetCompletedTasksUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetCompletedTasksUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetCompletedTasksUseCaseTest {
+    private lateinit var repository: FakeTaskRepository
+    private lateinit var getCompletedTasksUseCase: GetCompletedTasksUseCase
+
+    @Before
+    fun setup() {
+        repository = FakeTaskRepository()
+        getCompletedTasksUseCase = GetCompletedTasksUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns empty list when no tasks exist`() =
+        runTest {
+            val tasks = getCompletedTasksUseCase().first()
+
+            assertTrue(tasks.isEmpty())
+        }
+
+    @Test
+    fun `invoke returns only completed tasks`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Completed Task", isCompleted = true, createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(title = "Incomplete Task", isCompleted = false, createdAt = 2000L, updatedAt = 2000L),
+            )
+            repository.addTask(
+                Task(title = "Another Completed", isCompleted = true, createdAt = 3000L, updatedAt = 3000L),
+            )
+
+            val tasks = getCompletedTasksUseCase().first()
+
+            assertEquals(2, tasks.size)
+            assertTrue(tasks.all { it.isCompleted })
+            assertEquals("Completed Task", tasks[0].title)
+            assertEquals("Another Completed", tasks[1].title)
+        }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetTasksByCategoryUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetTasksByCategoryUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetTasksByCategoryUseCaseTest {
+    private lateinit var repository: FakeTaskRepository
+    private lateinit var getTasksByCategoryUseCase: GetTasksByCategoryUseCase
+
+    @Before
+    fun setup() {
+        repository = FakeTaskRepository()
+        getTasksByCategoryUseCase = GetTasksByCategoryUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns empty list when no tasks match category`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Work task", category = "Work", createdAt = 1000L, updatedAt = 1000L),
+            )
+
+            val tasks = getTasksByCategoryUseCase("Personal").first()
+
+            assertTrue(tasks.isEmpty())
+        }
+
+    @Test
+    fun `invoke returns only tasks matching the given category`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Work task 1", category = "Work", createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(title = "Personal task", category = "Personal", createdAt = 2000L, updatedAt = 2000L),
+            )
+            repository.addTask(
+                Task(title = "Work task 2", category = "Work", createdAt = 3000L, updatedAt = 3000L),
+            )
+
+            val tasks = getTasksByCategoryUseCase("Work").first()
+
+            assertEquals(2, tasks.size)
+            assertTrue(tasks.all { it.category == "Work" })
+            assertEquals("Work task 1", tasks[0].title)
+            assertEquals("Work task 2", tasks[1].title)
+        }
+
+    @Test
+    fun `invoke excludes completed tasks with matching category`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Active work", category = "Work", createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(
+                    title = "Completed work",
+                    category = "Work",
+                    isCompleted = true,
+                    createdAt = 2000L,
+                    updatedAt = 2000L,
+                ),
+            )
+
+            val tasks = getTasksByCategoryUseCase("Work").first()
+
+            assertEquals(1, tasks.size)
+            assertEquals("Active work", tasks[0].title)
+        }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetTasksByPriorityUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/GetTasksByPriorityUseCaseTest.kt
@@ -1,0 +1,76 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.Task
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetTasksByPriorityUseCaseTest {
+    private lateinit var repository: FakeTaskRepository
+    private lateinit var getTasksByPriorityUseCase: GetTasksByPriorityUseCase
+
+    @Before
+    fun setup() {
+        repository = FakeTaskRepository()
+        getTasksByPriorityUseCase = GetTasksByPriorityUseCase(repository)
+    }
+
+    @Test
+    fun `invoke returns empty list when no tasks match priority`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Low task", priority = Priority.LOW, createdAt = 1000L, updatedAt = 1000L),
+            )
+
+            val tasks = getTasksByPriorityUseCase(Priority.HIGH).first()
+
+            assertTrue(tasks.isEmpty())
+        }
+
+    @Test
+    fun `invoke returns only tasks matching the given priority`() =
+        runTest {
+            repository.addTask(
+                Task(title = "High task 1", priority = Priority.HIGH, createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(title = "Medium task", priority = Priority.MEDIUM, createdAt = 2000L, updatedAt = 2000L),
+            )
+            repository.addTask(
+                Task(title = "High task 2", priority = Priority.HIGH, createdAt = 3000L, updatedAt = 3000L),
+            )
+
+            val tasks = getTasksByPriorityUseCase(Priority.HIGH).first()
+
+            assertEquals(2, tasks.size)
+            assertTrue(tasks.all { it.priority == Priority.HIGH })
+            assertEquals("High task 1", tasks[0].title)
+            assertEquals("High task 2", tasks[1].title)
+        }
+
+    @Test
+    fun `invoke excludes completed tasks with matching priority`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Active high", priority = Priority.HIGH, createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(
+                    title = "Completed high",
+                    priority = Priority.HIGH,
+                    isCompleted = true,
+                    createdAt = 2000L,
+                    updatedAt = 2000L,
+                ),
+            )
+
+            val tasks = getTasksByPriorityUseCase(Priority.HIGH).first()
+
+            assertEquals(1, tasks.size)
+            assertEquals("Active high", tasks[0].title)
+        }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/domain/usecase/SearchTasksUseCaseTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/usecase/SearchTasksUseCaseTest.kt
@@ -1,0 +1,82 @@
+package com.nshaddox.randomtask.domain.usecase
+
+import com.nshaddox.randomtask.domain.model.Task
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SearchTasksUseCaseTest {
+    private lateinit var repository: FakeTaskRepository
+    private lateinit var searchTasksUseCase: SearchTasksUseCase
+
+    @Before
+    fun setup() {
+        repository = FakeTaskRepository()
+        searchTasksUseCase = SearchTasksUseCase(repository)
+    }
+
+    @Test
+    fun `invoke with blank query returns empty list`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Buy groceries", createdAt = 1000L, updatedAt = 1000L),
+            )
+
+            val tasks = searchTasksUseCase("").first()
+
+            assertTrue(tasks.isEmpty())
+        }
+
+    @Test
+    fun `invoke with whitespace-only query returns empty list`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Buy groceries", createdAt = 1000L, updatedAt = 1000L),
+            )
+
+            val tasks = searchTasksUseCase("   ").first()
+
+            assertTrue(tasks.isEmpty())
+        }
+
+    @Test
+    fun `invoke with non-blank query returns matching tasks`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Buy groceries", createdAt = 1000L, updatedAt = 1000L),
+            )
+            repository.addTask(
+                Task(title = "Clean house", createdAt = 2000L, updatedAt = 2000L),
+            )
+            repository.addTask(
+                Task(
+                    title = "Walk dog",
+                    description = "Buy treats first",
+                    createdAt = 3000L,
+                    updatedAt = 3000L,
+                ),
+            )
+
+            val tasks = searchTasksUseCase("Buy").first()
+
+            assertEquals(2, tasks.size)
+            assertEquals("Buy groceries", tasks[0].title)
+            assertEquals("Walk dog", tasks[1].title)
+        }
+
+    @Test
+    fun `invoke trims query before searching`() =
+        runTest {
+            repository.addTask(
+                Task(title = "Buy groceries", createdAt = 1000L, updatedAt = 1000L),
+            )
+
+            val tasks = searchTasksUseCase("  Buy  ").first()
+
+            assertEquals(1, tasks.size)
+            assertEquals("Buy groceries", tasks[0].title)
+        }
+}


### PR DESCRIPTION
## Summary

Add four new domain use cases for querying tasks: `GetCompletedTasksUseCase`, `SearchTasksUseCase`, `GetTasksByPriorityUseCase`, and `GetTasksByCategoryUseCase`. These wrap existing repository methods as use-case contracts consumable by ViewModels.

**Research**: `.rpi/04-new-query-usecases/research.md`
**Plan**: `.rpi/04-new-query-usecases/plan.md`
**Permanent Recap**: `docs/rpi/04-new-query-usecases.md`
**Upstream Dependencies**: None

## RPI Metrics

| Metric | Value |
|--------|-------|
| FAR Score | 5.00 |
| FACTS Score | 4.40 |
| Tasks Planned | 4 |
| Tasks Completed | 4 |
| Deviations from Plan | 0 |

## Key Changes Made

- **GetCompletedTasksUseCase** — delegates to `repository.getCompletedTasks()` (GH#206)
- **SearchTasksUseCase** — blank-query guard + delegates to `repository.searchTasks(query.trim())` (GH#207)
- **GetTasksByPriorityUseCase** — delegates to `repository.getTasksByPriority(priority)` (GH#208)
- **GetTasksByCategoryUseCase** — delegates to `repository.getTasksByCategory(category)` (GH#209)
- 12 new unit tests with 100% branch coverage on SearchTasksUseCase

## Checklist

- [x] **Unit Tests**: 12 new tests, all passing
- [x] **Local Regression**: `./gradlew lintDebug testDebugUnitTest` passes
- [x] **Plan Compliance**: All 4 plan tasks addressed
- [x] **Research Alignment**: Implementation follows research findings exactly
- [x] **Domain Purity**: Zero Android imports in production files

## Related

- Issues: GH#206, GH#207, GH#208, GH#209
- Part of: RPI Orchestrate run 2026-03-14 (2 features)

🤖 Generated with [Claude Code](https://claude.ai/code)