### PR TITLE
feat(05): UI state extensions

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/domain/model/AppTheme.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/model/AppTheme.kt
@@ -1,0 +1,18 @@
+package com.nshaddox.randomtask.domain.model
+
+/**
+ * Represents the visual theme preference for the application.
+ *
+ * Used by [SettingsUiState][com.nshaddox.randomtask.ui.screens.settings.SettingsUiState]
+ * to store and expose the user's chosen theme.
+ */
+enum class AppTheme {
+    /** Always use light color scheme. */
+    LIGHT,
+
+    /** Always use dark color scheme. */
+    DARK,
+
+    /** Follow the device system setting for light or dark mode. */
+    SYSTEM,
+}

--- a/app/src/main/java/com/nshaddox/randomtask/domain/model/SortOrder.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/domain/model/SortOrder.kt
@@ -1,0 +1,22 @@
+package com.nshaddox.randomtask.domain.model
+
+/**
+ * Represents the available sort orderings for task lists.
+ *
+ * Used by both [TaskListUiState][com.nshaddox.randomtask.ui.screens.tasklist.TaskListUiState]
+ * and [SettingsUiState][com.nshaddox.randomtask.ui.screens.settings.SettingsUiState]
+ * to control how tasks are displayed.
+ */
+enum class SortOrder {
+    /** Sort by creation date, newest first. */
+    CREATED_DATE_DESC,
+
+    /** Sort by due date, earliest first. */
+    DUE_DATE_ASC,
+
+    /** Sort by priority, highest first. */
+    PRIORITY_DESC,
+
+    /** Sort alphabetically by title, A-Z. */
+    TITLE_ASC,
+}

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksUiState.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksUiState.kt
@@ -1,0 +1,16 @@
+package com.nshaddox.randomtask.ui.screens.completedtasks
+
+import com.nshaddox.randomtask.domain.model.Task
+
+/**
+ * UI state for the completed tasks screen.
+ *
+ * @property tasks The list of completed tasks to display.
+ * @property isLoading Whether a loading operation is in progress.
+ * @property errorMessage An optional error message to display. Null when there is no error.
+ */
+data class CompletedTasksUiState(
+    val tasks: List<Task> = emptyList(),
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/settings/SettingsUiState.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/settings/SettingsUiState.kt
@@ -1,0 +1,19 @@
+package com.nshaddox.randomtask.ui.screens.settings
+
+import com.nshaddox.randomtask.domain.model.AppTheme
+import com.nshaddox.randomtask.domain.model.SortOrder
+
+/**
+ * UI state for the settings screen.
+ *
+ * @property appTheme The user's selected visual theme preference.
+ * @property sortOrder The user's selected default sort order for task lists.
+ * @property isLoading Whether a settings operation (load or save) is in progress.
+ * @property errorMessage An optional error message to display. Null when there is no error.
+ */
+data class SettingsUiState(
+    val appTheme: AppTheme = AppTheme.SYSTEM,
+    val sortOrder: SortOrder = SortOrder.CREATED_DATE_DESC,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
@@ -1,5 +1,7 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
 import com.nshaddox.randomtask.domain.model.Task
 
 /**
@@ -9,10 +11,21 @@ import com.nshaddox.randomtask.domain.model.Task
  * @property isLoading Whether a loading operation is in progress.
  * @property errorMessage An optional error message to display. Null when there is no error.
  * @property isAddDialogVisible Whether the add-task dialog is currently visible.
+ * @property searchQuery The current text entered in the search field. Empty string when inactive.
+ * @property filterPriority The priority filter currently applied. Null when no priority filter is active.
+ * @property filterCategory The category filter currently applied. Null when no category filter is active.
+ * @property sortOrder The current sort ordering for the task list.
+ * @property availableCategories The list of distinct category values present in the task list,
+ *   used to populate filter UI.
  */
 data class TaskListUiState(
     val tasks: List<Task> = emptyList(),
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
     val isAddDialogVisible: Boolean = false,
+    val searchQuery: String = "",
+    val filterPriority: Priority? = null,
+    val filterCategory: String? = null,
+    val sortOrder: SortOrder = SortOrder.CREATED_DATE_DESC,
+    val availableCategories: List<String> = emptyList(),
 )

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiMappers.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiMappers.kt
@@ -1,5 +1,6 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import com.nshaddox.randomtask.domain.model.Priority
 import com.nshaddox.randomtask.domain.model.Task
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -8,7 +9,27 @@ import java.util.Locale
 private fun formatTimestamp(epochMillis: Long): String =
     SimpleDateFormat("MMM d, yyyy h:mm a", Locale.US).format(Date(epochMillis))
 
-fun Task.toUiModel(): TaskUiModel =
+private const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
+
+private fun formatEpochDays(epochDays: Long): String {
+    val epochMillis = epochDays * MILLIS_PER_DAY
+    return SimpleDateFormat("MMM d, yyyy", Locale.US).format(Date(epochMillis))
+}
+
+private fun priorityToLabel(priority: Priority): String =
+    when (priority) {
+        Priority.HIGH -> "High"
+        Priority.MEDIUM -> "Medium"
+        Priority.LOW -> "Low"
+    }
+
+/**
+ * Maps a [Task] domain model to a [TaskUiModel] with pre-formatted display values.
+ *
+ * @param currentEpochDay The current date expressed as epoch days (days since 1970-01-01),
+ *   used to determine whether the task is overdue. Callers should pass today's epoch-day value.
+ */
+fun Task.toUiModel(currentEpochDay: Long): TaskUiModel =
     TaskUiModel(
         id = id,
         title = title,
@@ -16,4 +37,9 @@ fun Task.toUiModel(): TaskUiModel =
         isCompleted = isCompleted,
         createdAt = formatTimestamp(createdAt),
         updatedAt = formatTimestamp(updatedAt),
+        priority = priority,
+        priorityLabel = priorityToLabel(priority),
+        dueDateLabel = dueDate?.let { formatEpochDays(it) },
+        isOverdue = dueDate != null && dueDate < currentEpochDay,
+        category = category,
     )

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiModel.kt
@@ -1,5 +1,7 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import com.nshaddox.randomtask.domain.model.Priority
+
 /**
  * UI model representing a task with pre-formatted display values.
  *
@@ -9,6 +11,11 @@ package com.nshaddox.randomtask.ui.screens.tasklist
  * @property isCompleted Whether the task has been marked as done.
  * @property createdAt Formatted date string for when the task was created.
  * @property updatedAt Formatted date string for when the task was last modified.
+ * @property priority The priority level of the task.
+ * @property priorityLabel Human-readable label for the priority (e.g., "High", "Medium", "Low").
+ * @property dueDateLabel Formatted due date string (e.g., "Jan 15, 2025"). Null when no due date is set.
+ * @property isOverdue Whether the task is past its due date.
+ * @property category Optional category label for the task. Null when not set.
  */
 data class TaskUiModel(
     val id: Long,
@@ -17,4 +24,9 @@ data class TaskUiModel(
     val isCompleted: Boolean,
     val createdAt: String,
     val updatedAt: String,
+    val priority: Priority = Priority.MEDIUM,
+    val priorityLabel: String = "Medium",
+    val dueDateLabel: String? = null,
+    val isOverdue: Boolean = false,
+    val category: String? = null,
 )

--- a/app/src/test/java/com/nshaddox/randomtask/domain/model/AppThemeTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/model/AppThemeTest.kt
@@ -1,0 +1,40 @@
+package com.nshaddox.randomtask.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppThemeTest {
+    @Test
+    fun `AppTheme has three values`() {
+        val values = AppTheme.entries
+        assertEquals(3, values.size)
+    }
+
+    @Test
+    fun `AppTheme values are in expected order`() {
+        val values = AppTheme.entries
+        assertEquals(AppTheme.LIGHT, values[0])
+        assertEquals(AppTheme.DARK, values[1])
+        assertEquals(AppTheme.SYSTEM, values[2])
+    }
+
+    @Test
+    fun `valueOf LIGHT returns LIGHT`() {
+        assertEquals(AppTheme.LIGHT, AppTheme.valueOf("LIGHT"))
+    }
+
+    @Test
+    fun `valueOf DARK returns DARK`() {
+        assertEquals(AppTheme.DARK, AppTheme.valueOf("DARK"))
+    }
+
+    @Test
+    fun `valueOf SYSTEM returns SYSTEM`() {
+        assertEquals(AppTheme.SYSTEM, AppTheme.valueOf("SYSTEM"))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `valueOf invalid name throws IllegalArgumentException`() {
+        AppTheme.valueOf("INVALID")
+    }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/domain/model/SortOrderTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/domain/model/SortOrderTest.kt
@@ -1,0 +1,46 @@
+package com.nshaddox.randomtask.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SortOrderTest {
+    @Test
+    fun `SortOrder has four values`() {
+        val values = SortOrder.entries
+        assertEquals(4, values.size)
+    }
+
+    @Test
+    fun `SortOrder values are in expected order`() {
+        val values = SortOrder.entries
+        assertEquals(SortOrder.CREATED_DATE_DESC, values[0])
+        assertEquals(SortOrder.DUE_DATE_ASC, values[1])
+        assertEquals(SortOrder.PRIORITY_DESC, values[2])
+        assertEquals(SortOrder.TITLE_ASC, values[3])
+    }
+
+    @Test
+    fun `valueOf CREATED_DATE_DESC returns CREATED_DATE_DESC`() {
+        assertEquals(SortOrder.CREATED_DATE_DESC, SortOrder.valueOf("CREATED_DATE_DESC"))
+    }
+
+    @Test
+    fun `valueOf DUE_DATE_ASC returns DUE_DATE_ASC`() {
+        assertEquals(SortOrder.DUE_DATE_ASC, SortOrder.valueOf("DUE_DATE_ASC"))
+    }
+
+    @Test
+    fun `valueOf PRIORITY_DESC returns PRIORITY_DESC`() {
+        assertEquals(SortOrder.PRIORITY_DESC, SortOrder.valueOf("PRIORITY_DESC"))
+    }
+
+    @Test
+    fun `valueOf TITLE_ASC returns TITLE_ASC`() {
+        assertEquals(SortOrder.TITLE_ASC, SortOrder.valueOf("TITLE_ASC"))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `valueOf invalid name throws IllegalArgumentException`() {
+        SortOrder.valueOf("INVALID")
+    }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksUiStateTest.kt
@@ -1,0 +1,114 @@
+package com.nshaddox.randomtask.ui.screens.completedtasks
+
+import com.nshaddox.randomtask.domain.model.Task
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompletedTasksUiStateTest {
+    // ── Default value tests ──
+
+    @Test
+    fun `default state has empty task list`() {
+        val state = CompletedTasksUiState()
+        assertTrue(state.tasks.isEmpty())
+    }
+
+    @Test
+    fun `default state is loading`() {
+        val state = CompletedTasksUiState()
+        assertTrue(state.isLoading)
+    }
+
+    @Test
+    fun `default state has no error`() {
+        val state = CompletedTasksUiState()
+        assertNull(state.errorMessage)
+    }
+
+    // ── Copy transition tests ──
+
+    @Test
+    fun `copy to loaded state with tasks`() {
+        val tasks =
+            listOf(
+                Task(
+                    id = 1,
+                    title = "Done Task",
+                    isCompleted = true,
+                    createdAt = 1000L,
+                    updatedAt = 2000L,
+                ),
+            )
+        val state = CompletedTasksUiState()
+        val loaded = state.copy(tasks = tasks, isLoading = false)
+
+        assertEquals(1, loaded.tasks.size)
+        assertEquals("Done Task", loaded.tasks[0].title)
+        assertFalse(loaded.isLoading)
+        assertNull(loaded.errorMessage)
+    }
+
+    @Test
+    fun `copy to error state`() {
+        val state = CompletedTasksUiState()
+        val error = state.copy(isLoading = false, errorMessage = "Failed to load")
+
+        assertFalse(error.isLoading)
+        assertEquals("Failed to load", error.errorMessage)
+        assertTrue(error.tasks.isEmpty())
+    }
+
+    @Test
+    fun `copy with tasks preserves other defaults`() {
+        val task =
+            Task(
+                id = 1,
+                title = "Task",
+                isCompleted = true,
+                createdAt = 1000L,
+                updatedAt = 2000L,
+            )
+        val state = CompletedTasksUiState(tasks = listOf(task))
+
+        assertEquals(1, state.tasks.size)
+        assertTrue(state.isLoading)
+        assertNull(state.errorMessage)
+    }
+
+    // ── Equality tests ──
+
+    @Test
+    fun `equality for identical default states`() {
+        val state1 = CompletedTasksUiState()
+        val state2 = CompletedTasksUiState()
+        assertEquals(state1, state2)
+    }
+
+    @Test
+    fun `equality for states with same tasks`() {
+        val task =
+            Task(
+                id = 1,
+                title = "Task",
+                isCompleted = true,
+                createdAt = 1000L,
+                updatedAt = 2000L,
+            )
+        val state1 = CompletedTasksUiState(tasks = listOf(task), isLoading = false)
+        val state2 = CompletedTasksUiState(tasks = listOf(task), isLoading = false)
+        assertEquals(state1, state2)
+    }
+
+    // ── toString test ──
+
+    @Test
+    fun `toString contains field values`() {
+        val state = CompletedTasksUiState(isLoading = false, errorMessage = "oops")
+        val str = state.toString()
+        assertTrue(str.contains("isLoading=false"))
+        assertTrue(str.contains("errorMessage=oops"))
+    }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/settings/SettingsUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/settings/SettingsUiStateTest.kt
@@ -1,0 +1,124 @@
+package com.nshaddox.randomtask.ui.screens.settings
+
+import com.nshaddox.randomtask.domain.model.AppTheme
+import com.nshaddox.randomtask.domain.model.SortOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsUiStateTest {
+    // ── Default value tests ──
+
+    @Test
+    fun `default state has appTheme SYSTEM`() {
+        val state = SettingsUiState()
+        assertEquals(AppTheme.SYSTEM, state.appTheme)
+    }
+
+    @Test
+    fun `default state has sortOrder CREATED_DATE_DESC`() {
+        val state = SettingsUiState()
+        assertEquals(SortOrder.CREATED_DATE_DESC, state.sortOrder)
+    }
+
+    @Test
+    fun `default state is not loading`() {
+        val state = SettingsUiState()
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `default state has no error`() {
+        val state = SettingsUiState()
+        assertNull(state.errorMessage)
+    }
+
+    // ── Copy transition tests ──
+
+    @Test
+    fun `copy with appTheme LIGHT`() {
+        val state = SettingsUiState()
+        val updated = state.copy(appTheme = AppTheme.LIGHT)
+        assertEquals(AppTheme.LIGHT, updated.appTheme)
+    }
+
+    @Test
+    fun `copy with appTheme DARK`() {
+        val state = SettingsUiState()
+        val updated = state.copy(appTheme = AppTheme.DARK)
+        assertEquals(AppTheme.DARK, updated.appTheme)
+    }
+
+    @Test
+    fun `copy with sortOrder DUE_DATE_ASC`() {
+        val state = SettingsUiState()
+        val updated = state.copy(sortOrder = SortOrder.DUE_DATE_ASC)
+        assertEquals(SortOrder.DUE_DATE_ASC, updated.sortOrder)
+    }
+
+    @Test
+    fun `copy with sortOrder PRIORITY_DESC`() {
+        val state = SettingsUiState()
+        val updated = state.copy(sortOrder = SortOrder.PRIORITY_DESC)
+        assertEquals(SortOrder.PRIORITY_DESC, updated.sortOrder)
+    }
+
+    @Test
+    fun `copy with sortOrder TITLE_ASC`() {
+        val state = SettingsUiState()
+        val updated = state.copy(sortOrder = SortOrder.TITLE_ASC)
+        assertEquals(SortOrder.TITLE_ASC, updated.sortOrder)
+    }
+
+    @Test
+    fun `copy with isLoading true`() {
+        val state = SettingsUiState()
+        val updated = state.copy(isLoading = true)
+        assertTrue(updated.isLoading)
+    }
+
+    @Test
+    fun `copy with errorMessage`() {
+        val state = SettingsUiState()
+        val updated = state.copy(errorMessage = "Save failed")
+        assertEquals("Save failed", updated.errorMessage)
+    }
+
+    @Test
+    fun `copy preserves other defaults`() {
+        val state = SettingsUiState()
+        val updated = state.copy(appTheme = AppTheme.DARK)
+        assertEquals(AppTheme.DARK, updated.appTheme)
+        assertEquals(SortOrder.CREATED_DATE_DESC, updated.sortOrder)
+        assertFalse(updated.isLoading)
+        assertNull(updated.errorMessage)
+    }
+
+    // ── Equality tests ──
+
+    @Test
+    fun `equality for identical default states`() {
+        val state1 = SettingsUiState()
+        val state2 = SettingsUiState()
+        assertEquals(state1, state2)
+    }
+
+    @Test
+    fun `equality for states with same values`() {
+        val state1 = SettingsUiState(appTheme = AppTheme.DARK, sortOrder = SortOrder.TITLE_ASC)
+        val state2 = SettingsUiState(appTheme = AppTheme.DARK, sortOrder = SortOrder.TITLE_ASC)
+        assertEquals(state1, state2)
+    }
+
+    // ── toString test ──
+
+    @Test
+    fun `toString contains field values`() {
+        val state = SettingsUiState(appTheme = AppTheme.LIGHT, sortOrder = SortOrder.PRIORITY_DESC)
+        val str = state.toString()
+        assertTrue(str.contains("appTheme=LIGHT"))
+        assertTrue(str.contains("sortOrder=PRIORITY_DESC"))
+    }
+}

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
@@ -1,5 +1,7 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
 import com.nshaddox.randomtask.domain.model.Task
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -91,5 +93,104 @@ class TaskListUiStateTest {
         val str = state.toString()
         assertTrue(str.contains("isLoading=true"))
         assertTrue(str.contains("errorMessage=fail"))
+    }
+
+    // ── New field default tests ──
+
+    @Test
+    fun `default state has empty searchQuery`() {
+        val state = TaskListUiState()
+        assertEquals("", state.searchQuery)
+    }
+
+    @Test
+    fun `default state has null filterPriority`() {
+        val state = TaskListUiState()
+        assertNull(state.filterPriority)
+    }
+
+    @Test
+    fun `default state has null filterCategory`() {
+        val state = TaskListUiState()
+        assertNull(state.filterCategory)
+    }
+
+    @Test
+    fun `default state has sortOrder CREATED_DATE_DESC`() {
+        val state = TaskListUiState()
+        assertEquals(SortOrder.CREATED_DATE_DESC, state.sortOrder)
+    }
+
+    @Test
+    fun `default state has empty availableCategories`() {
+        val state = TaskListUiState()
+        assertTrue(state.availableCategories.isEmpty())
+    }
+
+    // ── New field copy-transition tests ──
+
+    @Test
+    fun `copy with searchQuery`() {
+        val state = TaskListUiState()
+        val withSearch = state.copy(searchQuery = "buy")
+        assertEquals("buy", withSearch.searchQuery)
+    }
+
+    @Test
+    fun `copy with filterPriority`() {
+        val state = TaskListUiState()
+        val filtered = state.copy(filterPriority = Priority.HIGH)
+        assertEquals(Priority.HIGH, filtered.filterPriority)
+    }
+
+    @Test
+    fun `copy with filterCategory`() {
+        val state = TaskListUiState()
+        val filtered = state.copy(filterCategory = "Work")
+        assertEquals("Work", filtered.filterCategory)
+    }
+
+    @Test
+    fun `copy with sortOrder`() {
+        val state = TaskListUiState()
+        val sorted = state.copy(sortOrder = SortOrder.TITLE_ASC)
+        assertEquals(SortOrder.TITLE_ASC, sorted.sortOrder)
+    }
+
+    @Test
+    fun `copy with availableCategories`() {
+        val state = TaskListUiState()
+        val categories = listOf("Work", "Personal", "Shopping")
+        val withCategories = state.copy(availableCategories = categories)
+        assertEquals(3, withCategories.availableCategories.size)
+        assertEquals("Work", withCategories.availableCategories[0])
+        assertEquals("Personal", withCategories.availableCategories[1])
+        assertEquals("Shopping", withCategories.availableCategories[2])
+    }
+
+    @Test
+    fun `copy preserves new field defaults when not overridden`() {
+        val state = TaskListUiState()
+        val copied = state.copy(isLoading = false)
+        assertEquals("", copied.searchQuery)
+        assertNull(copied.filterPriority)
+        assertNull(copied.filterCategory)
+        assertEquals(SortOrder.CREATED_DATE_DESC, copied.sortOrder)
+        assertTrue(copied.availableCategories.isEmpty())
+    }
+
+    @Test
+    fun `equality for states with same new fields`() {
+        val state1 = TaskListUiState(searchQuery = "test", sortOrder = SortOrder.DUE_DATE_ASC)
+        val state2 = TaskListUiState(searchQuery = "test", sortOrder = SortOrder.DUE_DATE_ASC)
+        assertEquals(state1, state2)
+    }
+
+    @Test
+    fun `toString contains new field values`() {
+        val state = TaskListUiState(searchQuery = "groceries", sortOrder = SortOrder.PRIORITY_DESC)
+        val str = state.toString()
+        assertTrue(str.contains("searchQuery=groceries"))
+        assertTrue(str.contains("sortOrder=PRIORITY_DESC"))
     }
 }

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiMappersTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiMappersTest.kt
@@ -1,15 +1,21 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import com.nshaddox.randomtask.domain.model.Priority
 import com.nshaddox.randomtask.domain.model.Task
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.TimeZone
 
 class TaskUiMappersTest {
     private lateinit var originalTimeZone: TimeZone
+
+    /** A fixed epoch day value used as "today" in tests. */
+    private val todayEpochDay = 20000L
 
     @Before
     fun setUp() {
@@ -21,6 +27,8 @@ class TaskUiMappersTest {
     fun tearDown() {
         TimeZone.setDefault(originalTimeZone)
     }
+
+    // ── Existing field mapping tests (updated to pass currentEpochDay) ──
 
     @Test
     fun `toUiModel maps all fields correctly`() {
@@ -34,7 +42,7 @@ class TaskUiMappersTest {
                 updatedAt = 2000L,
             )
 
-        val uiModel = task.toUiModel()
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
 
         assertEquals(1L, uiModel.id)
         assertEquals("Test Task", uiModel.title)
@@ -56,7 +64,7 @@ class TaskUiMappersTest {
                 updatedAt = 2000L,
             )
 
-        val uiModel = task.toUiModel()
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
 
         assertNull(uiModel.description)
     }
@@ -73,7 +81,7 @@ class TaskUiMappersTest {
                 updatedAt = 0L,
             )
 
-        val uiModel = task.toUiModel()
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
 
         assertEquals("Jan 1, 1970 12:00 AM", uiModel.createdAt)
         assertEquals("Jan 1, 1970 12:00 AM", uiModel.updatedAt)
@@ -92,9 +100,225 @@ class TaskUiMappersTest {
                 updatedAt = 1737046200000L,
             )
 
-        val uiModel = task.toUiModel()
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
 
         assertEquals("Jan 16, 2025 4:50 PM", uiModel.createdAt)
         assertEquals("Jan 16, 2025 4:50 PM", uiModel.updatedAt)
     }
+
+    // ── Priority mapping tests ──
+
+    @Test
+    fun `toUiModel maps HIGH priority`() {
+        val task = createTask(priority = Priority.HIGH)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals(Priority.HIGH, uiModel.priority)
+    }
+
+    @Test
+    fun `toUiModel maps MEDIUM priority`() {
+        val task = createTask(priority = Priority.MEDIUM)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals(Priority.MEDIUM, uiModel.priority)
+    }
+
+    @Test
+    fun `toUiModel maps LOW priority`() {
+        val task = createTask(priority = Priority.LOW)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals(Priority.LOW, uiModel.priority)
+    }
+
+    // ── Priority label tests ──
+
+    @Test
+    fun `toUiModel maps HIGH priority to label High`() {
+        val task = createTask(priority = Priority.HIGH)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("High", uiModel.priorityLabel)
+    }
+
+    @Test
+    fun `toUiModel maps MEDIUM priority to label Medium`() {
+        val task = createTask(priority = Priority.MEDIUM)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("Medium", uiModel.priorityLabel)
+    }
+
+    @Test
+    fun `toUiModel maps LOW priority to label Low`() {
+        val task = createTask(priority = Priority.LOW)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("Low", uiModel.priorityLabel)
+    }
+
+    // ── Due date label tests ──
+
+    @Test
+    fun `toUiModel maps null dueDate to null dueDateLabel`() {
+        val task = createTask(dueDate = null)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertNull(uiModel.dueDateLabel)
+    }
+
+    @Test
+    fun `toUiModel maps epoch day 0 to formatted date`() {
+        // Epoch day 0 = Jan 1, 1970
+        val task = createTask(dueDate = 0L)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("Jan 1, 1970", uiModel.dueDateLabel)
+    }
+
+    @Test
+    fun `toUiModel maps known epoch day to formatted date`() {
+        // Epoch day 20088 = Dec 31, 2024 (20088 days from Jan 1, 1970)
+        val task = createTask(dueDate = 20088L)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("Dec 31, 2024", uiModel.dueDateLabel)
+    }
+
+    // ── isOverdue tests (three boundary cases) ──
+
+    @Test
+    fun `toUiModel isOverdue is true when dueDate is before today`() {
+        val task = createTask(dueDate = todayEpochDay - 1)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertTrue(uiModel.isOverdue)
+    }
+
+    @Test
+    fun `toUiModel isOverdue is false when dueDate equals today`() {
+        val task = createTask(dueDate = todayEpochDay)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertFalse(uiModel.isOverdue)
+    }
+
+    @Test
+    fun `toUiModel isOverdue is false when dueDate is null`() {
+        val task = createTask(dueDate = null)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertFalse(uiModel.isOverdue)
+    }
+
+    @Test
+    fun `toUiModel isOverdue is false when dueDate is after today`() {
+        val task = createTask(dueDate = todayEpochDay + 1)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertFalse(uiModel.isOverdue)
+    }
+
+    // ── Category mapping tests ──
+
+    @Test
+    fun `toUiModel maps null category correctly`() {
+        val task = createTask(category = null)
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertNull(uiModel.category)
+    }
+
+    @Test
+    fun `toUiModel maps non-null category correctly`() {
+        val task = createTask(category = "Work")
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals("Work", uiModel.category)
+    }
+
+    // ── Combined new fields test ──
+
+    @Test
+    fun `toUiModel maps all new fields together`() {
+        val task =
+            Task(
+                id = 10L,
+                title = "Full Task",
+                description = "Complete task",
+                isCompleted = false,
+                createdAt = 1000L,
+                updatedAt = 2000L,
+                priority = Priority.HIGH,
+                dueDate = todayEpochDay - 1,
+                category = "Personal",
+            )
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals(Priority.HIGH, uiModel.priority)
+        assertEquals("High", uiModel.priorityLabel)
+        assertTrue(uiModel.isOverdue)
+        assertEquals("Personal", uiModel.category)
+        // dueDateLabel should be a non-null formatted string
+        assertTrue(uiModel.dueDateLabel != null)
+    }
+
+    // ── Default new fields when task uses defaults ──
+
+    @Test
+    fun `toUiModel with default task fields maps priority to MEDIUM`() {
+        val task = createTask()
+
+        val uiModel = task.toUiModel(currentEpochDay = todayEpochDay)
+
+        assertEquals(Priority.MEDIUM, uiModel.priority)
+        assertEquals("Medium", uiModel.priorityLabel)
+        assertNull(uiModel.dueDateLabel)
+        assertFalse(uiModel.isOverdue)
+        assertNull(uiModel.category)
+    }
+
+    /**
+     * Helper to create a task with sensible defaults for mapper tests.
+     */
+    @Suppress("LongParameterList")
+    private fun createTask(
+        id: Long = 1L,
+        title: String = "Test",
+        description: String? = null,
+        isCompleted: Boolean = false,
+        createdAt: Long = 1000L,
+        updatedAt: Long = 2000L,
+        priority: Priority = Priority.MEDIUM,
+        dueDate: Long? = null,
+        category: String? = null,
+    ): Task =
+        Task(
+            id = id,
+            title = title,
+            description = description,
+            isCompleted = isCompleted,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            priority = priority,
+            dueDate = dueDate,
+            category = category,
+        )
 }

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiModelTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskUiModelTest.kt
@@ -1,0 +1,226 @@
+package com.nshaddox.randomtask.ui.screens.tasklist
+
+import com.nshaddox.randomtask.domain.model.Priority
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TaskUiModelTest {
+    @Suppress("LongParameterList")
+    private fun createModel(
+        id: Long = 1L,
+        title: String = "Test",
+        description: String? = null,
+        isCompleted: Boolean = false,
+        createdAt: String = "Jan 1, 2025 12:00 AM",
+        updatedAt: String = "Jan 1, 2025 12:00 AM",
+        priority: Priority = Priority.MEDIUM,
+        priorityLabel: String = "Medium",
+        dueDateLabel: String? = null,
+        isOverdue: Boolean = false,
+        category: String? = null,
+    ): TaskUiModel =
+        TaskUiModel(
+            id = id,
+            title = title,
+            description = description,
+            isCompleted = isCompleted,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+            priority = priority,
+            priorityLabel = priorityLabel,
+            dueDateLabel = dueDateLabel,
+            isOverdue = isOverdue,
+            category = category,
+        )
+
+    // ── Default value tests ──
+
+    @Test
+    fun `default priority is MEDIUM`() {
+        val model =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        assertEquals(Priority.MEDIUM, model.priority)
+    }
+
+    @Test
+    fun `default priorityLabel is Medium`() {
+        val model =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        assertEquals("Medium", model.priorityLabel)
+    }
+
+    @Test
+    fun `default dueDateLabel is null`() {
+        val model =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        assertNull(model.dueDateLabel)
+    }
+
+    @Test
+    fun `default isOverdue is false`() {
+        val model =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        assertFalse(model.isOverdue)
+    }
+
+    @Test
+    fun `default category is null`() {
+        val model =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        assertNull(model.category)
+    }
+
+    // ── Copy tests for new fields ──
+
+    @Test
+    fun `copy with priority`() {
+        val model = createModel()
+        val copied = model.copy(priority = Priority.HIGH)
+        assertEquals(Priority.HIGH, copied.priority)
+    }
+
+    @Test
+    fun `copy with priorityLabel`() {
+        val model = createModel()
+        val copied = model.copy(priorityLabel = "High")
+        assertEquals("High", copied.priorityLabel)
+    }
+
+    @Test
+    fun `copy with dueDateLabel`() {
+        val model = createModel()
+        val copied = model.copy(dueDateLabel = "Dec 31, 2025")
+        assertEquals("Dec 31, 2025", copied.dueDateLabel)
+    }
+
+    @Test
+    fun `copy with isOverdue`() {
+        val model = createModel()
+        val copied = model.copy(isOverdue = true)
+        assertTrue(copied.isOverdue)
+    }
+
+    @Test
+    fun `copy with category`() {
+        val model = createModel()
+        val copied = model.copy(category = "Work")
+        assertEquals("Work", copied.category)
+    }
+
+    // ── Equality tests ──
+
+    @Test
+    fun `equality for identical models`() {
+        val model1 = createModel()
+        val model2 = createModel()
+        assertEquals(model1, model2)
+    }
+
+    @Test
+    fun `inequality when priority differs`() {
+        val model1 = createModel(priority = Priority.HIGH)
+        val model2 = createModel(priority = Priority.LOW)
+        assertNotEquals(model1, model2)
+    }
+
+    @Test
+    fun `inequality when isOverdue differs`() {
+        val model1 = createModel(isOverdue = true)
+        val model2 = createModel(isOverdue = false)
+        assertNotEquals(model1, model2)
+    }
+
+    @Test
+    fun `inequality when category differs`() {
+        val model1 = createModel(category = "Work")
+        val model2 = createModel(category = "Personal")
+        assertNotEquals(model1, model2)
+    }
+
+    // ── toString test ──
+
+    @Test
+    fun `toString contains new field values`() {
+        val model =
+            createModel(
+                priority = Priority.HIGH,
+                priorityLabel = "High",
+                dueDateLabel = "Jan 15, 2025",
+                isOverdue = true,
+                category = "Work",
+            )
+        val str = model.toString()
+        assertTrue(str.contains("priority=HIGH"))
+        assertTrue(str.contains("priorityLabel=High"))
+        assertTrue(str.contains("dueDateLabel=Jan 15, 2025"))
+        assertTrue(str.contains("isOverdue=true"))
+        assertTrue(str.contains("category=Work"))
+    }
+
+    // ── hashCode test ──
+
+    @Test
+    fun `hashCode is same for equal models`() {
+        val model1 = createModel(priority = Priority.HIGH, category = "Work")
+        val model2 = createModel(priority = Priority.HIGH, category = "Work")
+        assertEquals(model1.hashCode(), model2.hashCode())
+    }
+
+    // ── Full model test ──
+
+    @Test
+    fun `model with all new fields populated`() {
+        val model =
+            createModel(
+                priority = Priority.LOW,
+                priorityLabel = "Low",
+                dueDateLabel = "Mar 14, 2026",
+                isOverdue = false,
+                category = "Personal",
+            )
+        assertEquals(Priority.LOW, model.priority)
+        assertEquals("Low", model.priorityLabel)
+        assertEquals("Mar 14, 2026", model.dueDateLabel)
+        assertFalse(model.isOverdue)
+        assertEquals("Personal", model.category)
+    }
+}


### PR DESCRIPTION
## Summary

Extend UI state layer for v2.0: add display fields to `TaskUiModel`, create `CompletedTasksUiState` and `SettingsUiState`, add search/filter/sort fields to `TaskListUiState`, and introduce `AppTheme` and `SortOrder` domain enums.

**Research**: `.rpi/05-ui-state-updates/research.md`
**Plan**: `.rpi/05-ui-state-updates/plan.md`
**Permanent Recap**: `docs/rpi/05-ui-state-updates.md`
**Upstream Dependencies**: None

## RPI Metrics

| Metric | Value |
|--------|-------|
| FAR Score | 4.67 |
| FACTS Score | 4.57 |
| Tasks Planned | 6 |
| Tasks Completed | 6 |
| Deviations from Plan | 0 |

## Key Changes Made

- **AppTheme + SortOrder enums** in `domain.model` — pure Kotlin, no Android deps (GH#212)
- **TaskUiModel** extended with `priority`, `priorityLabel`, `dueDateLabel`, `isOverdue`, `category` (GH#210)
- **toUiModel()** mapper updated with `currentEpochDay` param for testable overdue logic (GH#210)
- **TaskListUiState** extended with `searchQuery`, `filterPriority`, `filterCategory`, `sortOrder`, `availableCategories` (GH#213)
- **CompletedTasksUiState** created in `ui.screens.completedtasks` (GH#211)
- **SettingsUiState** created in `ui.screens.settings` (GH#212)
- ~73 new unit tests across 7 test files

## Checklist

- [x] **Unit Tests**: ~73 new tests, all passing
- [x] **Local Regression**: `./gradlew lintDebug testDebugUnitTest` passes
- [x] **Plan Compliance**: All 6 plan tasks addressed
- [x] **Research Alignment**: Implementation follows research findings exactly
- [x] **Domain Purity**: Zero Android imports in domain layer

## Related

- Issues: GH#210, GH#211, GH#212, GH#213
- Part of: RPI Orchestrate run 2026-03-14 (2 features)

🤖 Generated with [Claude Code](https://claude.ai/code)