### PR TITLE
feat(vm): implement CompletedTasksViewModel (GH#215)

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModel.kt
@@ -1,0 +1,51 @@
+package com.nshaddox.randomtask.ui.screens.completedtasks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.usecase.DeleteTaskUseCase
+import com.nshaddox.randomtask.domain.usecase.GetCompletedTasksUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class CompletedTasksViewModel
+    @Inject
+    constructor(
+        private val getCompletedTasksUseCase: GetCompletedTasksUseCase,
+        private val deleteTaskUseCase: DeleteTaskUseCase,
+        @Named("IO") private val ioDispatcher: CoroutineDispatcher,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(CompletedTasksUiState())
+        val uiState: StateFlow<CompletedTasksUiState> = _uiState.asStateFlow()
+
+        init {
+            viewModelScope.launch(ioDispatcher) {
+                getCompletedTasksUseCase().collect { tasks ->
+                    _uiState.update { it.copy(tasks = tasks, isLoading = false) }
+                }
+            }
+        }
+
+        fun deleteTask(task: Task) {
+            viewModelScope.launch(ioDispatcher) {
+                deleteTaskUseCase(task)
+                    .onFailure { error ->
+                        _uiState.update {
+                            it.copy(errorMessage = error.message ?: "Failed to delete task")
+                        }
+                    }
+            }
+        }
+
+        fun clearError() {
+            _uiState.update { it.copy(errorMessage = null) }
+        }
+    }

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModelTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModelTest.kt
@@ -1,0 +1,163 @@
+package com.nshaddox.randomtask.ui.screens.completedtasks
+
+import app.cash.turbine.test
+import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.domain.usecase.DeleteTaskUseCase
+import com.nshaddox.randomtask.domain.usecase.FakeTaskRepository
+import com.nshaddox.randomtask.domain.usecase.GetCompletedTasksUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CompletedTasksViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: FakeTaskRepository
+    private lateinit var getCompletedTasksUseCase: GetCompletedTasksUseCase
+    private lateinit var deleteTaskUseCase: DeleteTaskUseCase
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        repository = FakeTaskRepository()
+        getCompletedTasksUseCase = GetCompletedTasksUseCase(repository)
+        deleteTaskUseCase = DeleteTaskUseCase(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel() =
+        CompletedTasksViewModel(
+            getCompletedTasksUseCase = getCompletedTasksUseCase,
+            deleteTaskUseCase = deleteTaskUseCase,
+            ioDispatcher = testDispatcher,
+        )
+
+    private fun createTask(
+        id: Long = 0,
+        title: String = "Test Task",
+        isCompleted: Boolean = true,
+    ) = Task(
+        id = id,
+        title = title,
+        isCompleted = isCompleted,
+        createdAt = 1000L,
+        updatedAt = 1000L,
+    )
+
+    @Test
+    fun `initial state is loading then transitions to empty list`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial state from MutableStateFlow default
+                val initial = awaitItem()
+                assertTrue(initial.isLoading)
+                assertTrue(initial.tasks.isEmpty())
+
+                // After init block collects from repository
+                val loaded = awaitItem()
+                assertFalse(loaded.isLoading)
+                assertTrue(loaded.tasks.isEmpty())
+            }
+        }
+
+    @Test
+    fun `initial state transitions to populated completed tasks list`() =
+        runTest(testDispatcher) {
+            repository.addTask(createTask(title = "Completed Task 1", isCompleted = true))
+            repository.addTask(createTask(title = "Completed Task 2", isCompleted = true))
+            // Add an incomplete task to verify it is filtered out
+            repository.addTask(createTask(title = "Incomplete Task", isCompleted = false))
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading state
+                val initial = awaitItem()
+                assertTrue(initial.isLoading)
+
+                // Loaded state with only completed tasks
+                val loaded = awaitItem()
+                assertFalse(loaded.isLoading)
+                assertEquals(2, loaded.tasks.size)
+                assertTrue(loaded.tasks.all { it.isCompleted })
+            }
+        }
+
+    @Test
+    fun `deleteTask success removes task via repository flow update`() =
+        runTest(testDispatcher) {
+            repository.addTask(createTask(title = "Task to delete", isCompleted = true))
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded with task
+                val loaded = awaitItem()
+                assertEquals(1, loaded.tasks.size)
+                val taskToDelete = loaded.tasks[0]
+
+                viewModel.deleteTask(taskToDelete)
+
+                val afterDelete = awaitItem()
+                assertTrue(afterDelete.tasks.isEmpty())
+            }
+        }
+
+    @Test
+    fun `deleteTask failure sets errorMessage`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded empty
+                awaitItem()
+
+                viewModel.deleteTask(createTask(id = 999, title = "Nonexistent"))
+
+                val errorState = awaitItem()
+                assertEquals("Task not found", errorState.errorMessage)
+            }
+        }
+
+    @Test
+    fun `clearError resets errorMessage to null`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded empty
+                awaitItem()
+
+                // Trigger an error by deleting a non-existent task
+                viewModel.deleteTask(createTask(id = 999, title = "Nonexistent"))
+
+                val errorState = awaitItem()
+                assertEquals("Task not found", errorState.errorMessage)
+
+                viewModel.clearError()
+
+                val clearedState = awaitItem()
+                assertNull(clearedState.errorMessage)
+            }
+        }
+}


### PR DESCRIPTION
## Summary
- Created `CompletedTasksViewModel` in `ui.screens.completedtasks` package following existing ViewModel patterns
- Implements `@HiltViewModel` with `GetCompletedTasksUseCase` and `DeleteTaskUseCase` injection
- Exposes `StateFlow<CompletedTasksUiState>` with reactive task collection and delete capability

## Key Changes
- **CompletedTasksViewModel.kt**: New ViewModel with init-block Flow collection, `deleteTask()`, `clearError()`, `@Named("IO")` dispatcher
- **CompletedTasksViewModelTest.kt**: 5 unit tests covering initial loading, task population, delete success, delete failure, and error clearing

## Test Plan
- [x] 5 new unit tests pass
- [x] `./gradlew lintDebug testDebugUnitTest` passes
- [x] Pre-commit hook passes
- [x] Follows TaskListViewModel pattern exactly

## Research & Plan
- Research: `.rpi/07-completed-tasks-vm/research.md` (FAR 5.00)
- Plan: `.rpi/07-completed-tasks-vm/plan.md` (FACTS 4.20)
- Review: APPROVE (Round 1) — 0C/0H/0M/1L

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)