### PR TITLE
feat(vm,nav): implement SettingsViewModel and navigation routes (GH#216, GH#217)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
     implementation(libs.navigation.compose)
     ksp(libs.hilt.compiler)
+    implementation(libs.datastore.preferences)
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)

--- a/app/src/main/java/com/nshaddox/randomtask/di/DataStoreModule.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/di/DataStoreModule.kt
@@ -1,0 +1,29 @@
+package com.nshaddox.randomtask.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    @Provides
+    @Singleton
+    fun provideDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            produceFile = { context.filesDir.resolve("settings_prefs.preferences_pb") },
+        )
+}

--- a/app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt
@@ -18,4 +18,10 @@ sealed class Screen(val route: String) {
     data object EditTask : Screen("edit_task/{taskId}") {
         fun createRoute(taskId: Long): String = "edit_task/$taskId"
     }
+
+    /** Route to the completed tasks history screen. */
+    data object CompletedTasks : Screen("completed_tasks")
+
+    /** Route to the settings screen where users configure app preferences. */
+    data object Settings : Screen("settings")
 }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/settings/SettingsViewModel.kt
@@ -1,0 +1,79 @@
+package com.nshaddox.randomtask.ui.screens.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nshaddox.randomtask.domain.model.AppTheme
+import com.nshaddox.randomtask.domain.model.SortOrder
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+@HiltViewModel
+class SettingsViewModel
+    @Inject
+    constructor(
+        private val dataStore: DataStore<Preferences>,
+        @Named("IO") private val ioDispatcher: CoroutineDispatcher,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(SettingsUiState())
+        val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+        init {
+            viewModelScope.launch(ioDispatcher) {
+                dataStore.data.collect { preferences ->
+                    val theme = preferences.readEnum(THEME_KEY, AppTheme.SYSTEM)
+                    val sortOrder = preferences.readEnum(SORT_ORDER_KEY, SortOrder.CREATED_DATE_DESC)
+                    _uiState.value = SettingsUiState(appTheme = theme, sortOrder = sortOrder)
+                }
+            }
+        }
+
+        fun setTheme(theme: AppTheme) {
+            viewModelScope.launch(ioDispatcher) {
+                dataStore.edit { prefs ->
+                    prefs[THEME_KEY] = theme.name
+                }
+            }
+        }
+
+        fun setSortOrder(sortOrder: SortOrder) {
+            viewModelScope.launch(ioDispatcher) {
+                dataStore.edit { prefs ->
+                    prefs[SORT_ORDER_KEY] = sortOrder.name
+                }
+            }
+        }
+
+        private companion object {
+            val THEME_KEY = stringPreferencesKey("app_theme")
+            val SORT_ORDER_KEY = stringPreferencesKey("sort_order")
+        }
+    }
+
+/**
+ * Reads an enum value from DataStore preferences with a safe fallback.
+ *
+ * @param key The preference key to read.
+ * @param default The default value if the key is missing or the stored value is invalid.
+ * @return The enum value stored under [key], or [default] if not found or unparseable.
+ */
+private inline fun <reified T : Enum<T>> Preferences.readEnum(
+    key: Preferences.Key<String>,
+    default: T,
+): T =
+    this[key]?.let { stored ->
+        try {
+            enumValueOf<T>(stored)
+        } catch (_: IllegalArgumentException) {
+            default
+        }
+    } ?: default

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/settings/SettingsViewModelTest.kt
@@ -1,0 +1,136 @@
+package com.nshaddox.randomtask.ui.screens.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import app.cash.turbine.test
+import com.nshaddox.randomtask.domain.model.AppTheme
+import com.nshaddox.randomtask.domain.model.SortOrder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var dataStoreScope: TestScope
+    private lateinit var dataStore: DataStore<Preferences>
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        dataStoreScope = TestScope(testDispatcher + Job())
+        dataStore =
+            PreferenceDataStoreFactory.create(
+                scope = dataStoreScope,
+                produceFile = { tempFolder.newFile("test_settings.preferences_pb") },
+            )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(store: DataStore<Preferences> = dataStore) =
+        SettingsViewModel(
+            dataStore = store,
+            ioDispatcher = testDispatcher,
+        )
+
+    @Test
+    fun `initial state emits SettingsUiState defaults`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                val initial = awaitItem()
+                assertEquals(AppTheme.SYSTEM, initial.appTheme)
+                assertEquals(SortOrder.CREATED_DATE_DESC, initial.sortOrder)
+            }
+        }
+
+    @Test
+    fun `setTheme DARK updates uiState appTheme to DARK`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial defaults
+                awaitItem()
+
+                viewModel.setTheme(AppTheme.DARK)
+
+                val updated = awaitItem()
+                assertEquals(AppTheme.DARK, updated.appTheme)
+            }
+        }
+
+    @Test
+    fun `setSortOrder TITLE_ASC updates uiState sortOrder to TITLE_ASC`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial defaults
+                awaitItem()
+
+                viewModel.setSortOrder(SortOrder.TITLE_ASC)
+
+                val updated = awaitItem()
+                assertEquals(SortOrder.TITLE_ASC, updated.sortOrder)
+            }
+        }
+
+    @Test
+    fun `state persists across new VM instance reading same DataStore`() =
+        runTest(testDispatcher) {
+            val viewModel1 = createViewModel()
+
+            viewModel1.uiState.test {
+                // Initial defaults
+                awaitItem()
+
+                viewModel1.setTheme(AppTheme.LIGHT)
+                viewModel1.setSortOrder(SortOrder.PRIORITY_DESC)
+
+                // Consume updates until we see both changes applied
+                var state = awaitItem()
+                if (state.sortOrder != SortOrder.PRIORITY_DESC) {
+                    state = awaitItem()
+                }
+                assertEquals(AppTheme.LIGHT, state.appTheme)
+                assertEquals(SortOrder.PRIORITY_DESC, state.sortOrder)
+            }
+
+            // Create a second VM from the same DataStore
+            val viewModel2 = createViewModel()
+
+            viewModel2.uiState.test {
+                val initial = awaitItem()
+                // May be defaults briefly; await the DataStore-loaded state
+                if (initial.appTheme == AppTheme.SYSTEM) {
+                    val loaded = awaitItem()
+                    assertEquals(AppTheme.LIGHT, loaded.appTheme)
+                    assertEquals(SortOrder.PRIORITY_DESC, loaded.sortOrder)
+                } else {
+                    assertEquals(AppTheme.LIGHT, initial.appTheme)
+                    assertEquals(SortOrder.PRIORITY_DESC, initial.sortOrder)
+                }
+            }
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.9.2"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
+datastore = "1.1.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
@@ -29,6 +30,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }


### PR DESCRIPTION
## Summary
- Created `SettingsViewModel` with `DataStore<Preferences>` persistence for theme and sort order preferences
- Added `DataStoreModule` Hilt singleton for DataStore DI
- Added `Screen.CompletedTasks` and `Screen.Settings` navigation routes
- Added `datastore-preferences` dependency to version catalog and build script

## Key Changes
- **SettingsViewModel.kt**: New ViewModel with `setTheme()` and `setSortOrder()` backed by DataStore, reactive state updates, safe enum deserialization
- **DataStoreModule.kt**: New Hilt module providing `DataStore<Preferences>` singleton via `PreferenceDataStoreFactory`
- **NavRoutes.kt**: Added `Screen.CompletedTasks` and `Screen.Settings` data objects
- **SettingsViewModelTest.kt**: 4 unit tests with in-memory DataStore covering initial state, theme mutation, sort order mutation, and cross-VM persistence
- **libs.versions.toml + build.gradle.kts**: Added datastore-preferences 1.1.1

## Test Plan
- [x] 4 new unit tests pass
- [x] `./gradlew lintDebug testDebugUnitTest` passes
- [x] Pre-commit hook passes
- [x] DataStore persistence verified across ViewModel re-creation

## Research & Plan
- Research: `.rpi/08-settings-vm-nav-routes/research.md` (FAR 4.33)
- Plan: `.rpi/08-settings-vm-nav-routes/plan.md` (FACTS 4.28)
- Review: APPROVE (Round 1) — 0C/0H/1M/2L

Closes #216, Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)