### PR TITLE
docs: add RPI recap summaries for v2 groups 5-6 features

### DIFF
--- a/docs/rpi/06-tasklist-vm-update.md
+++ b/docs/rpi/06-tasklist-vm-update.md
@@ -1,0 +1,37 @@
+# TaskList ViewModel: Search/Filter/Sort
+
+**Implemented**: 2026-03-14
+**Complexity**: medium
+
+## What Changed
+
+- Added reactive `combine` infrastructure to orchestrate `GetTasksUseCase` flow with four `MutableStateFlow` parameters (`searchQuery`, `filterPriority`, `filterCategory`, `sortOrder`)
+- Implemented in-memory compound filtering: search via substring match on title/description, then stack priority and category filters on results
+- Added `availableCategories` derivation from full unfiltered task list on every raw task emission
+- Extended `addTask` signature to accept `priority`, `dueDate`, and `category` parameters, forwarded to `AddTaskUseCase`
+- Added four new public functions: `updateSearchQuery()`, `setFilterPriority()`, `setFilterCategory()`, `setSortOrder()`
+- Implemented sort comparators for all `SortOrder` values including null-safe `DUE_DATE_ASC` (nulls last)
+
+## Why
+
+Enables the task list screen to provide search, filter, and sort capabilities without new repository queries. The reactive combine pattern ensures any change to a filter/sort parameter automatically recomputes and emits the filtered/sorted task list. `availableCategories` is derived from the complete unfiltered dataset, so category filters show options regardless of active filters.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt` - Added 3 new use case injections, 4 private `MutableStateFlow` fields, reactive combine logic in init block, sort comparators, 4 public update functions, extended `addTask` signature
+- `app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModelTest.kt` - Added 15 new test cases (total: 27 tests) covering search, filters, compound scenarios, sort orders, and extended `addTask`
+
+## Implementation Notes
+
+- Used `combine` pattern on raw tasks flow and four parameter flows for reactive recomputation on any filter/sort change
+- Search filtering delegates to inline substring match (not `SearchTasksUseCase` lookup); then stacks priority/category filters as Kotlin collection operations
+- `SortOrder.DUE_DATE_ASC` uses `compareBy(nullsLast()) { it.dueDate }` for safe null handling
+- Added `@Suppress("TooManyFunctions")` to ViewModel (5 new public functions)
+- Did not inject `SearchTasksUseCase`, `GetTasksByPriorityUseCase`, or `GetTasksByCategoryUseCase` — in-memory filtering sufficient
+
+## Verification
+
+- Tests: 27 total, 15 new (all passing)
+- Lint: `./gradlew lintDebug` passed
+- Build: `./gradlew testDebugUnitTest` passed
+- Pre-commit: `./gradlew lintDebug testDebugUnitTest` passed

--- a/docs/rpi/07-completed-tasks-vm.md
+++ b/docs/rpi/07-completed-tasks-vm.md
@@ -1,0 +1,37 @@
+# CompletedTasksViewModel
+
+**Implemented**: 2026-03-14
+**Complexity**: simple
+
+## What Changed
+
+- Created `CompletedTasksViewModel.kt` with strict TDD pattern
+- Implemented `GetCompletedTasksUseCase` collection in init block
+- Added `deleteTask(Task)` action with failure error propagation
+- Added `clearError()` action for error state reset
+- Created comprehensive test suite: 5 tests covering all state transitions and error paths
+
+## Why
+
+Completed tasks screen requires a dedicated ViewModel to manage task lifecycle (load, display, delete) and handle errors. Follows established MVVM pattern from `TaskListViewModel` ensuring consistency across the codebase.
+
+## Key Files
+
+- `app/src/main/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModel.kt` - MVVM ViewModel with Hilt injection and IO dispatcher
+- `app/src/test/java/com/nshaddox/randomtask/ui/screens/completedtasks/CompletedTasksViewModelTest.kt` - TDD test suite for all branches
+
+## Implementation Notes
+
+- `@HiltViewModel` with `@Named("IO") CoroutineDispatcher` injection matches TaskListViewModel pattern
+- `StateFlow<CompletedTasksUiState>` exposes reactive UI state with tasks, isLoading, errorMessage
+- Init block collects completed tasks via `GetCompletedTasksUseCase` on viewModelScope
+- Error handling captures deletion failures and propagates error messages to UI
+- Test harness uses `StandardTestDispatcher` + `FakeTaskRepository` for deterministic testing
+
+## Verification
+
+- Build: SUCCESSFUL
+- Lint: 0 warnings
+- Tests: 5/5 passing (100% of CompletedTasksViewModelTest)
+- Full suite: 224 tests passing, 0 failures, 100% success
+- Coverage: All state transitions and error/success paths covered

--- a/docs/rpi/08-settings-vm-nav-routes.md
+++ b/docs/rpi/08-settings-vm-nav-routes.md
@@ -1,0 +1,39 @@
+# Settings ViewModel & Navigation Routes
+
+**Implemented**: 2026-03-14
+**Complexity**: medium
+
+## What Changed
+
+- Added `Screen.CompletedTasks` and `Screen.Settings` navigation route data objects to `NavRoutes.kt`
+- Created `DataStoreModule.kt` Hilt singleton provider for `DataStore<Preferences>`
+- Implemented `SettingsViewModel` exposing `StateFlow<SettingsUiState>` backed by DataStore persistence
+- Added `datastore-preferences` dependency (v1.1.1) to `libs.versions.toml` and `build.gradle.kts`
+
+## Why
+
+Enables app-wide settings persistence across process death. SettingsViewModel provides reactive settings management for theme and sort order preferences, persisted via DataStore. Two new navigation routes prepare the navigation graph for settings and completed tasks screens (composables implemented in separate features).
+
+## Key Files
+
+- `gradle/libs.versions.toml` - Added `datastore = "1.1.1"` version and library alias
+- `app/build.gradle.kts` - Added `datastore-preferences` implementation dependency
+- `app/src/main/java/com/nshaddox/randomtask/ui/navigation/NavRoutes.kt` - Added two data object routes with KDoc
+- `app/src/main/java/com/nshaddox/randomtask/di/DataStoreModule.kt` - New Hilt singleton provider using `PreferenceDataStoreFactory`
+- `app/src/main/java/com/nshaddox/randomtask/ui/screens/settings/SettingsViewModel.kt` - ViewModel with `setTheme()`, `setSortOrder()` methods
+
+## Implementation Notes
+
+- Followed existing `DatabaseModule` pattern for Hilt singleton setup
+- Enum values (`AppTheme`, `SortOrder`) serialized as `.name` strings in DataStore with safe fallback via `enumValueOf<T>()`
+- ViewModel uses injected `@Named("IO")` dispatcher—no hardcoded `Dispatchers.IO`
+- Extracted `Preferences.readEnum()` helper extension to reduce duplication
+- Test scaffold uses in-memory DataStore with `PreferenceDataStoreFactory` + `StandardTestDispatcher`
+- Tested persistence across VM re-creation, theme/sort order updates, and default fallbacks
+
+## Verification
+
+- Build: `./gradlew assembleDebug` — PASS
+- Lint: `./gradlew lintDebug` — PASS
+- Tests: `./gradlew testDebugUnitTest` — PASS (4 new tests: initial state, setTheme, setSortOrder, persistence)
+- All pre-commit hooks pass (lintDebug + testDebugUnitTest)


### PR DESCRIPTION
## Summary
- Add permanent RPI implementation documentation for v2.0 Groups 5-6 features
- Covers TaskListViewModel update (#214), CompletedTasksViewModel (#215), SettingsViewModel + nav routes (#216, #217)

## Test plan
- [x] Documentation only — no code changes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)