### PR TITLE
feat(13): persist sort order via DataStore in TaskListViewModel (GH#229)

### DIFF
--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
@@ -1,5 +1,9 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nshaddox.randomtask.domain.model.Priority
@@ -19,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,6 +42,7 @@ class TaskListViewModel
         private val searchTasksUseCase: SearchTasksUseCase,
         private val getTasksByPriorityUseCase: GetTasksByPriorityUseCase,
         private val getTasksByCategoryUseCase: GetTasksByCategoryUseCase,
+        private val dataStore: DataStore<Preferences>,
         @Named("IO") private val ioDispatcher: CoroutineDispatcher,
     ) : ViewModel() {
         private val _uiState = MutableStateFlow(TaskListUiState())
@@ -49,6 +55,18 @@ class TaskListViewModel
 
         init {
             viewModelScope.launch(ioDispatcher) {
+                // Seed sortOrderFlow from persisted DataStore value before combine starts
+                val preferences = dataStore.data.first()
+                val persisted =
+                    preferences[SORT_ORDER_KEY]?.let { stored ->
+                        try {
+                            enumValueOf<SortOrder>(stored)
+                        } catch (_: IllegalArgumentException) {
+                            SortOrder.CREATED_DATE_DESC
+                        }
+                    } ?: SortOrder.CREATED_DATE_DESC
+                sortOrderFlow.value = persisted
+
                 combine(
                     getTasksUseCase(),
                     searchQueryFlow,
@@ -118,6 +136,11 @@ class TaskListViewModel
 
         fun setSortOrder(sortOrder: SortOrder) {
             sortOrderFlow.value = sortOrder
+            viewModelScope.launch(ioDispatcher) {
+                dataStore.edit { prefs ->
+                    prefs[SORT_ORDER_KEY] = sortOrder.name
+                }
+            }
         }
 
         fun addTask(
@@ -204,4 +227,8 @@ class TaskListViewModel
                 SortOrder.DUE_DATE_ASC ->
                     tasks.sortedWith(compareBy(nullsLast()) { it.dueDate })
             }
+
+        private companion object {
+            val SORT_ORDER_KEY = stringPreferencesKey("sort_order")
+        }
     }

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModelTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModelTest.kt
@@ -1,5 +1,10 @@
 package com.nshaddox.randomtask.ui.screens.tasklist
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import app.cash.turbine.test
 import com.nshaddox.randomtask.domain.model.Priority
 import com.nshaddox.randomtask.domain.model.SortOrder
@@ -15,7 +20,9 @@ import com.nshaddox.randomtask.domain.usecase.SearchTasksUseCase
 import com.nshaddox.randomtask.domain.usecase.UpdateTaskUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -26,8 +33,11 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
+@Suppress("LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 class TaskListViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -40,10 +50,21 @@ class TaskListViewModelTest {
     private lateinit var searchTasksUseCase: SearchTasksUseCase
     private lateinit var getTasksByPriorityUseCase: GetTasksByPriorityUseCase
     private lateinit var getTasksByCategoryUseCase: GetTasksByCategoryUseCase
+    private lateinit var dataStoreScope: TestScope
+    private lateinit var dataStore: DataStore<Preferences>
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        dataStoreScope = TestScope(testDispatcher + Job())
+        dataStore =
+            PreferenceDataStoreFactory.create(
+                scope = dataStoreScope,
+                produceFile = { tempFolder.newFile("test_tasklist.preferences_pb") },
+            )
         repository = FakeTaskRepository()
         getTasksUseCase = GetTasksUseCase(repository)
         addTaskUseCase = AddTaskUseCase(repository)
@@ -60,7 +81,7 @@ class TaskListViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel() =
+    private fun createViewModel(store: DataStore<Preferences> = dataStore) =
         TaskListViewModel(
             getTasksUseCase = getTasksUseCase,
             addTaskUseCase = addTaskUseCase,
@@ -70,6 +91,7 @@ class TaskListViewModelTest {
             searchTasksUseCase = searchTasksUseCase,
             getTasksByPriorityUseCase = getTasksByPriorityUseCase,
             getTasksByCategoryUseCase = getTasksByCategoryUseCase,
+            dataStore = store,
             ioDispatcher = testDispatcher,
         )
 
@@ -771,6 +793,65 @@ class TaskListViewModelTest {
                 assertEquals(Priority.MEDIUM, task.priority)
                 assertNull(task.dueDate)
                 assertNull(task.category)
+            }
+        }
+
+    // === Sort order persistence tests ===
+
+    @Test
+    fun `init reads persisted sort order from DataStore on startup`() =
+        runTest(testDispatcher) {
+            // Pre-write TITLE_ASC into DataStore before creating the ViewModel
+            val sortOrderKey = stringPreferencesKey("sort_order")
+            dataStore.edit { prefs ->
+                prefs[sortOrderKey] = SortOrder.TITLE_ASC.name
+            }
+            advanceUntilIdle()
+
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading state
+                val initial = awaitItem()
+                assertTrue(initial.isLoading)
+
+                // Loaded state should have the persisted sort order
+                val loaded = awaitItem()
+                assertFalse(loaded.isLoading)
+                assertEquals(SortOrder.TITLE_ASC, loaded.sortOrder)
+            }
+        }
+
+    @Test
+    fun `setSortOrder persists new sort order so next VM init restores it`() =
+        runTest(testDispatcher) {
+            val viewModel1 = createViewModel()
+
+            viewModel1.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded empty
+                awaitItem()
+
+                viewModel1.setSortOrder(SortOrder.PRIORITY_DESC)
+                advanceUntilIdle()
+
+                val updated = awaitItem()
+                assertEquals(SortOrder.PRIORITY_DESC, updated.sortOrder)
+            }
+
+            // Create a second VM from the same DataStore — it should read PRIORITY_DESC
+            val viewModel2 = createViewModel()
+
+            viewModel2.uiState.test {
+                // Initial loading state
+                val initial = awaitItem()
+                assertTrue(initial.isLoading)
+
+                // Loaded state should have the persisted sort order
+                val loaded = awaitItem()
+                assertFalse(loaded.isLoading)
+                assertEquals(SortOrder.PRIORITY_DESC, loaded.sortOrder)
             }
         }
 }


### PR DESCRIPTION
## Summary

- Bridges the DataStore persistence gap: `TaskListViewModel` now reads persisted sort order on init and writes back on change
- Sort logic was already fully implemented — this PR adds only the DataStore read/write + 2 persistence tests

## RPI Metrics

| Metric | Value |
|--------|-------|
| FAR Score | 4.67 |
| Tasks Planned | 3 |
| Tasks Completed | 3 |
| Review Verdict | APPROVE (0C/0H/1M/2L) |

## Key Changes

- `TaskListViewModel.kt` — Inject `DataStore<Preferences>`, read sort order in `init`, write in `setSortOrder()`
- `TaskListViewModelTest.kt` — 2 new persistence round-trip tests, DataStore test infrastructure

## Test Plan

- [x] All 30 tests pass (`./gradlew testDebugUnitTest`)
- [x] Lint passes (`./gradlew lintDebug`)

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>