### PR TITLE
feat(11): TaskFilterBar and TaskListScreen overhaul (GH#220, GH#222)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,6 +159,8 @@ val jacocoExclusions =
         "**/*ScreenPreviewKt*",
         "**/*DialogKt*",
         "**/*BadgeKt*",
+        "**/*FilterBarKt*",
+        "**/*PickerDialogKt*",
         "**/*Preview*",
         "**/SampleData*",
         // Android generated classes

--- a/app/src/androidTest/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialogTest.kt
+++ b/app/src/androidTest/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialogTest.kt
@@ -46,7 +46,7 @@ class EditTaskDialogTest {
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }
@@ -59,7 +59,7 @@ class EditTaskDialogTest {
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }
@@ -73,7 +73,7 @@ class EditTaskDialogTest {
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }
@@ -101,7 +101,7 @@ class EditTaskDialogTest {
             EditTaskDialog(
                 task = task,
                 initialDueDate = LocalDate.of(2026, 3, 14),
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }
@@ -124,15 +124,17 @@ class EditTaskDialogTest {
         var confirmedDescription: String? = null
         var confirmedPriority = Priority.MEDIUM
         var confirmedDueDate: LocalDate? = null
+        var confirmedCategory: String? = null
 
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { title, desc, priority, dueDate ->
+                onConfirm = { title, desc, priority, dueDate, category ->
                     confirmedTitle = title
                     confirmedDescription = desc
                     confirmedPriority = priority
                     confirmedDueDate = dueDate
+                    confirmedCategory = category
                 },
                 onDismiss = {},
             )
@@ -147,6 +149,7 @@ class EditTaskDialogTest {
         assertEquals("Some details", confirmedDescription)
         assertEquals(Priority.HIGH, confirmedPriority)
         assertNull(confirmedDueDate)
+        assertNull(confirmedCategory)
     }
 
     @Test
@@ -156,7 +159,7 @@ class EditTaskDialogTest {
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = { dismissCalled = true },
             )
         }
@@ -171,7 +174,7 @@ class EditTaskDialogTest {
         composeTestRule.setContent {
             EditTaskDialog(
                 task = null,
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }
@@ -192,7 +195,7 @@ class EditTaskDialogTest {
             EditTaskDialog(
                 task = task,
                 initialDueDate = LocalDate.of(2026, 3, 14),
-                onConfirm = { _, _, _, _ -> },
+                onConfirm = { _, _, _, _, _ -> },
                 onDismiss = {},
             )
         }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/preview/MockData.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/preview/MockData.kt
@@ -1,10 +1,13 @@
 package com.nshaddox.randomtask.ui.preview
 
+import com.nshaddox.randomtask.domain.model.Priority
 import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.ui.screens.tasklist.TaskUiModel
 
 /**
  * Sample task data for use in Compose previews
  */
+@Suppress("MagicNumber")
 object SampleData {
     val sampleTask =
         Task(
@@ -13,6 +16,9 @@ object SampleData {
             isCompleted = false,
             createdAt = 1_700_000_000_000L,
             updatedAt = 1_700_000_000_000L,
+            priority = Priority.HIGH,
+            dueDate = 20200L,
+            category = "Work",
         )
 
     val sampleTasks =
@@ -37,6 +43,9 @@ object SampleData {
                 isCompleted = false,
                 createdAt = 1_700_000_200_000L,
                 updatedAt = 1_700_000_200_000L,
+                priority = Priority.HIGH,
+                dueDate = 20200L,
+                category = "Work",
             ),
             Task(
                 4L,
@@ -44,6 +53,8 @@ object SampleData {
                 isCompleted = false,
                 createdAt = 1_700_000_300_000L,
                 updatedAt = 1_700_000_300_000L,
+                priority = Priority.MEDIUM,
+                category = "Work",
             ),
             Task(
                 5L,
@@ -51,6 +62,7 @@ object SampleData {
                 isCompleted = false,
                 createdAt = 1_700_000_400_000L,
                 updatedAt = 1_700_000_400_000L,
+                priority = Priority.LOW,
             ),
             Task(
                 6L,
@@ -58,6 +70,9 @@ object SampleData {
                 isCompleted = false,
                 createdAt = 1_700_000_500_000L,
                 updatedAt = 1_700_000_500_000L,
+                priority = Priority.HIGH,
+                dueDate = 19900L,
+                category = "Personal",
             ),
             Task(
                 7L,
@@ -87,5 +102,108 @@ object SampleData {
             isCompleted = false,
             createdAt = 1_700_000_000_000L,
             updatedAt = 1_700_000_000_000L,
+        )
+
+    // ── TaskUiModel samples for Compose previews ──
+
+    val sampleTaskUiModel =
+        TaskUiModel(
+            id = 1L,
+            title = "Complete project wireframes",
+            description = null,
+            isCompleted = false,
+            createdAt = "Nov 14, 2023 10:13 PM",
+            updatedAt = "Nov 14, 2023 10:13 PM",
+            priority = Priority.HIGH,
+            priorityLabel = "High",
+            dueDateLabel = "Apr 25, 2025",
+            isOverdue = false,
+            category = "Work",
+        )
+
+    val sampleTaskUiModels =
+        listOf(
+            TaskUiModel(
+                id = 1L,
+                title = "Setup development environment",
+                description = null,
+                isCompleted = true,
+                createdAt = "Nov 14, 2023 10:13 PM",
+                updatedAt = "Nov 14, 2023 10:13 PM",
+                priority = Priority.MEDIUM,
+                priorityLabel = "Medium",
+            ),
+            TaskUiModel(
+                id = 2L,
+                title = "Create project documentation",
+                description = null,
+                isCompleted = true,
+                createdAt = "Nov 14, 2023 10:15 PM",
+                updatedAt = "Nov 14, 2023 10:15 PM",
+                priority = Priority.MEDIUM,
+                priorityLabel = "Medium",
+            ),
+            TaskUiModel(
+                id = 3L,
+                title = "Design app wireframes",
+                description = null,
+                isCompleted = false,
+                createdAt = "Nov 14, 2023 10:16 PM",
+                updatedAt = "Nov 14, 2023 10:16 PM",
+                priority = Priority.HIGH,
+                priorityLabel = "High",
+                dueDateLabel = "Apr 25, 2025",
+                isOverdue = false,
+                category = "Work",
+            ),
+            TaskUiModel(
+                id = 4L,
+                title = "Implement Room database",
+                description = null,
+                isCompleted = false,
+                createdAt = "Nov 14, 2023 10:18 PM",
+                updatedAt = "Nov 14, 2023 10:18 PM",
+                priority = Priority.MEDIUM,
+                priorityLabel = "Medium",
+                category = "Work",
+            ),
+            TaskUiModel(
+                id = 5L,
+                title = "Add dependency injection with Hilt",
+                description = null,
+                isCompleted = false,
+                createdAt = "Nov 14, 2023 10:20 PM",
+                updatedAt = "Nov 14, 2023 10:20 PM",
+                priority = Priority.LOW,
+                priorityLabel = "Low",
+            ),
+            TaskUiModel(
+                id = 6L,
+                title = "Write unit tests",
+                description = null,
+                isCompleted = false,
+                createdAt = "Nov 14, 2023 10:21 PM",
+                updatedAt = "Nov 14, 2023 10:21 PM",
+                priority = Priority.HIGH,
+                priorityLabel = "High",
+                dueDateLabel = "Jun 23, 2024",
+                isOverdue = true,
+                category = "Personal",
+            ),
+        )
+
+    val sampleOverdueTaskUiModel =
+        TaskUiModel(
+            id = 10L,
+            title = "Submit overdue report",
+            description = "Quarterly review document",
+            isCompleted = false,
+            createdAt = "Jan 1, 2025 9:00 AM",
+            updatedAt = "Jan 1, 2025 9:00 AM",
+            priority = Priority.HIGH,
+            priorityLabel = "High",
+            dueDateLabel = "Feb 1, 2025",
+            isOverdue = true,
+            category = "Work",
         )
 }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialog.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialog.kt
@@ -34,17 +34,18 @@ import java.time.format.FormatStyle
  * when non-null it is in "edit" mode with fields pre-populated from the task.
  *
  * @param task The task to edit, or null for add mode.
- * @param onConfirm Called with title, optional description, priority, and optional due date
- *   when the user taps the confirm button.
+ * @param onConfirm Called with title, optional description, priority, optional due date,
+ *   and optional category when the user taps the confirm button.
  * @param onDismiss Called when the user cancels or dismisses the dialog.
  * @param initialDueDate The raw due date for pre-population in edit mode. Null when not set.
  * @param modifier Modifier for customization.
  */
+@Suppress("LongParameterList")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditTaskDialog(
     task: TaskUiModel?,
-    onConfirm: (String, String?, Priority, LocalDate?) -> Unit,
+    onConfirm: (String, String?, Priority, LocalDate?, String?) -> Unit,
     onDismiss: () -> Unit,
     initialDueDate: LocalDate? = null,
     modifier: Modifier = Modifier,
@@ -54,6 +55,7 @@ fun EditTaskDialog(
     var description by remember { mutableStateOf(task?.description.orEmpty()) }
     var priority by remember { mutableStateOf(task?.priority ?: Priority.MEDIUM) }
     var dueDate by remember { mutableStateOf(initialDueDate) }
+    var category by remember { mutableStateOf(task?.category.orEmpty()) }
     var showDatePicker by remember { mutableStateOf(false) }
 
     if (showDatePicker) {
@@ -80,6 +82,8 @@ fun EditTaskDialog(
                 onPriorityChange = { priority = it },
                 dueDate = dueDate,
                 onDueDateClick = { showDatePicker = true },
+                category = category,
+                onCategoryChange = { category = it },
             )
         },
         confirmButton = {
@@ -92,6 +96,7 @@ fun EditTaskDialog(
                         description.trim().ifBlank { null },
                         priority,
                         dueDate,
+                        category.trim().ifBlank { null },
                     )
                 },
             )
@@ -145,6 +150,8 @@ private fun EditTaskDialogContent(
     onPriorityChange: (Priority) -> Unit,
     dueDate: LocalDate?,
     onDueDateClick: () -> Unit,
+    category: String,
+    onCategoryChange: (String) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(Spacing.small)) {
         TextField(
@@ -166,6 +173,15 @@ private fun EditTaskDialogContent(
         )
         PrioritySelector(selected = priority, onSelect = onPriorityChange)
         DueDateField(dueDate = dueDate, onClick = onDueDateClick)
+        TextField(
+            value = category,
+            onValueChange = onCategoryChange,
+            placeholder = {
+                Text(stringResource(R.string.edit_task_dialog_placeholder_category))
+            },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialogPreview.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/EditTaskDialogPreview.kt
@@ -15,7 +15,7 @@ fun EditTaskDialogAddModePreview() {
     RandomTaskTheme {
         EditTaskDialog(
             task = null,
-            onConfirm = { _, _, _, _ -> },
+            onConfirm = { _, _, _, _, _ -> },
             onDismiss = {},
         )
     }
@@ -40,9 +40,10 @@ fun EditTaskDialogEditModePreview() {
                     priority = Priority.HIGH,
                     priorityLabel = "High",
                     dueDateLabel = "Mar 20, 2026",
+                    category = "Work",
                 ),
             initialDueDate = LocalDate.of(2026, 3, 20),
-            onConfirm = { _, _, _, _ -> },
+            onConfirm = { _, _, _, _, _ -> },
             onDismiss = {},
         )
     }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskFilterBar.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskFilterBar.kt
@@ -1,0 +1,272 @@
+package com.nshaddox.randomtask.ui.screens.tasklist
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.nshaddox.randomtask.R
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
+import com.nshaddox.randomtask.ui.theme.Spacing
+
+/**
+ * Filter/search bar for the task list screen.
+ *
+ * Provides search, priority filter chips, category filter dropdown,
+ * and sort order dropdown. Designed to sit between the TopAppBar and
+ * the task list.
+ *
+ * @param searchQuery The current search text.
+ * @param onSearchQueryChange Called when the search text changes.
+ * @param filterPriority The currently selected priority filter, or null for "All".
+ * @param onPriorityFilterChange Called when a priority filter chip is selected.
+ * @param filterCategory The currently selected category filter, or null for "All".
+ * @param onCategoryFilterChange Called when a category is selected from the dropdown.
+ * @param sortOrder The current sort ordering.
+ * @param onSortOrderChange Called when a sort order is selected from the dropdown.
+ * @param availableCategories The list of categories to show in the dropdown.
+ * @param modifier Modifier for customization.
+ */
+@Suppress("LongParameterList")
+@Composable
+fun TaskFilterBar(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    filterPriority: Priority?,
+    onPriorityFilterChange: (Priority?) -> Unit,
+    filterCategory: String?,
+    onCategoryFilterChange: (String?) -> Unit,
+    sortOrder: SortOrder,
+    onSortOrderChange: (SortOrder) -> Unit,
+    availableCategories: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = Spacing.medium, vertical = Spacing.small),
+        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        SearchField(
+            searchQuery = searchQuery,
+            onSearchQueryChange = onSearchQueryChange,
+        )
+        PriorityFilterChips(
+            filterPriority = filterPriority,
+            onPriorityFilterChange = onPriorityFilterChange,
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+        ) {
+            if (availableCategories.isNotEmpty()) {
+                CategoryDropdown(
+                    filterCategory = filterCategory,
+                    onCategoryFilterChange = onCategoryFilterChange,
+                    availableCategories = availableCategories,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            SortDropdown(
+                sortOrder = sortOrder,
+                onSortOrderChange = onSortOrderChange,
+                modifier =
+                    if (availableCategories.isNotEmpty()) {
+                        Modifier.weight(1f)
+                    } else {
+                        Modifier.fillMaxWidth()
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchField(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = searchQuery,
+        onValueChange = onSearchQueryChange,
+        placeholder = { Text(stringResource(R.string.filter_bar_search_hint)) },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+            )
+        },
+        trailingIcon = {
+            if (searchQuery.isNotEmpty()) {
+                IconButton(onClick = { onSearchQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Default.Clear,
+                        contentDescription = stringResource(R.string.filter_bar_clear_search),
+                    )
+                }
+            }
+        },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun PriorityFilterChips(
+    filterPriority: Priority?,
+    onPriorityFilterChange: (Priority?) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+    ) {
+        FilterChip(
+            selected = filterPriority == null,
+            onClick = { onPriorityFilterChange(null) },
+            label = { Text(stringResource(R.string.filter_bar_priority_all)) },
+        )
+        Priority.entries.forEach { priority ->
+            FilterChip(
+                selected = filterPriority == priority,
+                onClick = { onPriorityFilterChange(priority) },
+                label = { Text(stringResource(priorityLabelResId(priority))) },
+            )
+        }
+    }
+}
+
+/**
+ * Returns the string resource ID for the label of the given [priority].
+ */
+private fun priorityLabelResId(priority: Priority): Int =
+    when (priority) {
+        Priority.LOW -> R.string.priority_low
+        Priority.MEDIUM -> R.string.priority_medium
+        Priority.HIGH -> R.string.priority_high
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CategoryDropdown(
+    filterCategory: String?,
+    onCategoryFilterChange: (String?) -> Unit,
+    availableCategories: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = filterCategory ?: stringResource(R.string.filter_bar_category_all),
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+                Modifier
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                    .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.filter_bar_category_all)) },
+                onClick = {
+                    onCategoryFilterChange(null)
+                    expanded = false
+                },
+            )
+            availableCategories.forEach { category ->
+                DropdownMenuItem(
+                    text = { Text(category) },
+                    onClick = {
+                        onCategoryFilterChange(category)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortDropdown(
+    sortOrder: SortOrder,
+    onSortOrderChange: (SortOrder) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = modifier,
+    ) {
+        OutlinedTextField(
+            value = sortOrderLabel(sortOrder),
+            onValueChange = {},
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+                Modifier
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
+                    .fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            SortOrder.entries.forEach { order ->
+                DropdownMenuItem(
+                    text = { Text(sortOrderLabel(order)) },
+                    onClick = {
+                        onSortOrderChange(order)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun sortOrderLabel(sortOrder: SortOrder): String =
+    when (sortOrder) {
+        SortOrder.CREATED_DATE_DESC -> stringResource(R.string.sort_created_date_desc)
+        SortOrder.DUE_DATE_ASC -> stringResource(R.string.sort_due_date_asc)
+        SortOrder.PRIORITY_DESC -> stringResource(R.string.sort_priority_desc)
+        SortOrder.TITLE_ASC -> stringResource(R.string.sort_title_asc)
+    }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskFilterBarPreview.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskFilterBarPreview.kt
@@ -1,0 +1,70 @@
+package com.nshaddox.randomtask.ui.screens.tasklist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
+import com.nshaddox.randomtask.ui.theme.RandomTaskTheme
+
+/**
+ * Preview for TaskFilterBar with default state
+ */
+@PreviewLightDark
+@Composable
+fun TaskFilterBarDefaultPreview() {
+    RandomTaskTheme {
+        TaskFilterBar(
+            searchQuery = "",
+            onSearchQueryChange = {},
+            filterPriority = null,
+            onPriorityFilterChange = {},
+            filterCategory = null,
+            onCategoryFilterChange = {},
+            sortOrder = SortOrder.CREATED_DATE_DESC,
+            onSortOrderChange = {},
+            availableCategories = listOf("Work", "Personal", "Shopping"),
+        )
+    }
+}
+
+/**
+ * Preview for TaskFilterBar with active search and priority filter
+ */
+@PreviewLightDark
+@Composable
+fun TaskFilterBarActiveFiltersPreview() {
+    RandomTaskTheme {
+        TaskFilterBar(
+            searchQuery = "groceries",
+            onSearchQueryChange = {},
+            filterPriority = Priority.HIGH,
+            onPriorityFilterChange = {},
+            filterCategory = "Shopping",
+            onCategoryFilterChange = {},
+            sortOrder = SortOrder.PRIORITY_DESC,
+            onSortOrderChange = {},
+            availableCategories = listOf("Work", "Personal", "Shopping"),
+        )
+    }
+}
+
+/**
+ * Preview for TaskFilterBar without categories
+ */
+@PreviewLightDark
+@Composable
+fun TaskFilterBarNoCategoriesPreview() {
+    RandomTaskTheme {
+        TaskFilterBar(
+            searchQuery = "",
+            onSearchQueryChange = {},
+            filterPriority = null,
+            onPriorityFilterChange = {},
+            filterCategory = null,
+            onCategoryFilterChange = {},
+            sortOrder = SortOrder.CREATED_DATE_DESC,
+            onSortOrderChange = {},
+            availableCategories = emptyList(),
+        )
+    }
+}

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListScreen.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListScreen.kt
@@ -42,21 +42,28 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.nshaddox.randomtask.R
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
 import com.nshaddox.randomtask.domain.model.Task
+import com.nshaddox.randomtask.ui.components.PriorityBadge
 import com.nshaddox.randomtask.ui.navigation.Screen
 import com.nshaddox.randomtask.ui.theme.Spacing
+import java.time.LocalDate
 
 /**
  * ViewModel-connected TaskListScreen wrapper.
  *
  * Collects UI state from [TaskListViewModel] and delegates to the stateless composable.
+ * Converts domain [Task] objects to [TaskUiModel] for display.
  *
  * @param navController Navigation controller for screen transitions.
  * @param viewModel The TaskListViewModel instance, provided by Hilt.
  */
+@Suppress("LongMethod")
 @Composable
 fun TaskListScreen(
     navController: NavController,
@@ -77,23 +84,81 @@ fun TaskListScreen(
         }
     }
 
-    if (uiState.isAddDialogVisible) {
-        AddTaskDialog(
-            onConfirm = { title, description -> viewModel.addTask(title, description) },
-            onDismiss = { viewModel.hideAddDialog() },
+    val currentEpochDay = LocalDate.now().toEpochDay()
+    val taskUiModels =
+        remember(uiState.tasks, currentEpochDay) {
+            uiState.tasks.map { it.toUiModel(currentEpochDay) }
+        }
+
+    if (uiState.isEditDialogVisible || uiState.isAddDialogVisible) {
+        val editingTask = uiState.editingTask
+        val initialDueDate =
+            editingTask?.let { task ->
+                uiState.tasks.find { it.id == task.id }?.dueDate?.let {
+                    LocalDate.ofEpochDay(it)
+                }
+            }
+        EditTaskDialog(
+            task = editingTask,
+            onConfirm = { title, description, priority, dueDate, category ->
+                if (editingTask != null) {
+                    viewModel.editTask(
+                        taskId = editingTask.id,
+                        title = title,
+                        description = description,
+                        priority = priority,
+                        dueDate = dueDate?.toEpochDay(),
+                        category = category,
+                    )
+                } else {
+                    viewModel.addTask(
+                        title = title,
+                        description = description,
+                        priority = priority,
+                        dueDate = dueDate?.toEpochDay(),
+                        category = category,
+                    )
+                    viewModel.hideAddDialog()
+                }
+            },
+            onDismiss = {
+                if (editingTask != null) {
+                    viewModel.hideEditDialog()
+                } else {
+                    viewModel.hideAddDialog()
+                }
+            },
+            initialDueDate = initialDueDate,
         )
     }
 
     TaskListScreen(
-        tasks = uiState.tasks,
+        tasks = taskUiModels,
         isLoading = uiState.isLoading,
         errorMessage = uiState.errorMessage,
         snackbarHostState = snackbarHostState,
+        searchQuery = uiState.searchQuery,
+        filterPriority = uiState.filterPriority,
+        filterCategory = uiState.filterCategory,
+        sortOrder = uiState.sortOrder,
+        availableCategories = uiState.availableCategories,
+        onSearchQueryChange = { viewModel.updateSearchQuery(it) },
+        onPriorityFilterChange = { viewModel.setFilterPriority(it) },
+        onCategoryFilterChange = { viewModel.setFilterCategory(it) },
+        onSortOrderChange = { viewModel.setSortOrder(it) },
         onClearError = { viewModel.clearError() },
         onTaskClick = {},
-        onTaskCheckedChange = { task, _ -> viewModel.toggleTaskCompletion(task) },
-        onDeleteTask = { task -> viewModel.deleteTask(task) },
-        onEditTask = { task -> navController.navigate(Screen.EditTask.createRoute(task.id)) },
+        onTaskCheckedChange = { taskUiModel, _ ->
+            uiState.tasks.find { it.id == taskUiModel.id }?.let { task ->
+                viewModel.toggleTaskCompletion(task)
+            }
+        },
+        onDeleteTask = { taskUiModel ->
+            uiState.tasks.find { it.id == taskUiModel.id }?.let { task ->
+                viewModel.deleteTask(task)
+            }
+        },
+        onEditTask = { taskUiModel -> viewModel.showEditDialog(taskUiModel) },
         onAddTask = { viewModel.showAddDialog() },
         onNavigateToRandomTask = { navController.navigate(Screen.RandomTask.route) },
         onNavigateToCompletedTasks = { navController.navigate(Screen.CompletedTasks.route) },
@@ -102,35 +167,54 @@ fun TaskListScreen(
 }
 
 /**
- * Task List Screen - Displays a list of tasks with CRUD operations
+ * Task List Screen - Displays a list of tasks with CRUD operations, filter bar, and v2 fields.
  *
- * @param tasks List of tasks to display
- * @param isLoading Whether a loading operation is in progress
- * @param errorMessage An optional error message to display
- * @param onClearError Callback to clear the current error message
- * @param onTaskClick Callback when a task is clicked
- * @param onTaskCheckedChange Callback when task completion status changes
- * @param onDeleteTask Callback when delete button is clicked
- * @param onEditTask Callback when edit button is clicked
- * @param onAddTask Callback when FAB is clicked to add new task
- * @param onNavigateToRandomTask Callback when random task navigation button is clicked
- * @param onNavigateToCompletedTasks Callback when completed tasks history button is clicked
- * @param onNavigateToSettings Callback when settings navigation button is clicked
- * @param modifier Modifier for customization
+ * @param tasks List of task UI models to display.
+ * @param isLoading Whether a loading operation is in progress.
+ * @param errorMessage An optional error message to display.
+ * @param snackbarHostState The snackbar host state for displaying messages.
+ * @param searchQuery The current search text.
+ * @param filterPriority The currently selected priority filter, or null for "All".
+ * @param filterCategory The currently selected category filter, or null for "All".
+ * @param sortOrder The current sort ordering.
+ * @param availableCategories The list of categories for the filter dropdown.
+ * @param onSearchQueryChange Called when the search text changes.
+ * @param onPriorityFilterChange Called when a priority filter is selected.
+ * @param onCategoryFilterChange Called when a category filter is selected.
+ * @param onSortOrderChange Called when a sort order is selected.
+ * @param onClearError Callback to clear the current error message.
+ * @param onTaskClick Callback when a task is clicked.
+ * @param onTaskCheckedChange Callback when task completion status changes.
+ * @param onDeleteTask Callback when delete button is clicked.
+ * @param onEditTask Callback when edit button is clicked.
+ * @param onAddTask Callback when FAB is clicked to add new task.
+ * @param onNavigateToRandomTask Callback when random task navigation button is clicked.
+ * @param onNavigateToCompletedTasks Callback when completed tasks history button is clicked.
+ * @param onNavigateToSettings Callback when settings navigation button is clicked.
+ * @param modifier Modifier for customization.
  */
 @Suppress("LongParameterList", "LongMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskListScreen(
-    tasks: List<Task>,
+    tasks: List<TaskUiModel>,
     isLoading: Boolean = false,
     errorMessage: String? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    searchQuery: String = "",
+    filterPriority: Priority? = null,
+    filterCategory: String? = null,
+    sortOrder: SortOrder = SortOrder.CREATED_DATE_DESC,
+    availableCategories: List<String> = emptyList(),
+    onSearchQueryChange: (String) -> Unit = {},
+    onPriorityFilterChange: (Priority?) -> Unit = {},
+    onCategoryFilterChange: (String?) -> Unit = {},
+    onSortOrderChange: (SortOrder) -> Unit = {},
     onClearError: () -> Unit = {},
-    onTaskClick: (Task) -> Unit = {},
-    onTaskCheckedChange: (Task, Boolean) -> Unit = { _, _ -> },
-    onDeleteTask: (Task) -> Unit = {},
-    onEditTask: (Task) -> Unit = {},
+    onTaskClick: (TaskUiModel) -> Unit = {},
+    onTaskCheckedChange: (TaskUiModel, Boolean) -> Unit = { _, _ -> },
+    onDeleteTask: (TaskUiModel) -> Unit = {},
+    onEditTask: (TaskUiModel) -> Unit = {},
     onAddTask: () -> Unit = {},
     onNavigateToRandomTask: () -> Unit = {},
     onNavigateToCompletedTasks: () -> Unit = {},
@@ -201,7 +285,7 @@ fun TaskListScreen(
             ) {
                 CircularProgressIndicator()
             }
-        } else if (tasks.isEmpty()) {
+        } else if (tasks.isEmpty() && !hasActiveFilters(searchQuery, filterPriority, filterCategory)) {
             EmptyTaskListContent(
                 modifier =
                     Modifier
@@ -209,31 +293,58 @@ fun TaskListScreen(
                         .padding(innerPadding),
             )
         } else {
-            LazyColumn(
+            Column(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .padding(innerPadding)
-                        .padding(horizontal = Spacing.medium),
-                verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                        .padding(innerPadding),
             ) {
-                items(tasks, key = { it.id }) { task ->
-                    TaskListItem(
-                        task = task,
-                        onTaskClick = { onTaskClick(task) },
-                        onCheckedChange = { checked -> onTaskCheckedChange(task, checked) },
-                        onEditClick = { onEditTask(task) },
-                        onDeleteClick = { onDeleteTask(task) },
+                TaskFilterBar(
+                    searchQuery = searchQuery,
+                    onSearchQueryChange = onSearchQueryChange,
+                    filterPriority = filterPriority,
+                    onPriorityFilterChange = onPriorityFilterChange,
+                    filterCategory = filterCategory,
+                    onCategoryFilterChange = onCategoryFilterChange,
+                    sortOrder = sortOrder,
+                    onSortOrderChange = onSortOrderChange,
+                    availableCategories = availableCategories,
+                )
+                if (tasks.isEmpty()) {
+                    EmptyTaskListContent(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .weight(1f),
                     )
+                } else {
+                    LazyColumn(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = Spacing.medium),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        items(tasks, key = { it.id }) { task ->
+                            TaskListItem(
+                                task = task,
+                                onTaskClick = { onTaskClick(task) },
+                                onCheckedChange = { checked -> onTaskCheckedChange(task, checked) },
+                                onEditClick = { onEditTask(task) },
+                                onDeleteClick = { onDeleteTask(task) },
+                            )
+                        }
+                    }
                 }
             }
         }
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 internal fun TaskListItem(
-    task: Task,
+    task: TaskUiModel,
     onTaskClick: () -> Unit,
     onCheckedChange: (Boolean) -> Unit,
     onEditClick: () -> Unit,
@@ -270,22 +381,37 @@ internal fun TaskListItem(
                     checked = task.isCompleted,
                     onCheckedChange = onCheckedChange,
                 )
-                Text(
-                    text = task.title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    textDecoration =
-                        if (task.isCompleted) {
-                            TextDecoration.LineThrough
-                        } else {
-                            TextDecoration.None
-                        },
-                    color =
-                        if (task.isCompleted) {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        } else {
-                            MaterialTheme.colorScheme.onSurface
-                        },
-                )
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.extraSmall),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+                    ) {
+                        Text(
+                            text = task.title,
+                            style = MaterialTheme.typography.bodyLarge,
+                            textDecoration =
+                                if (task.isCompleted) {
+                                    TextDecoration.LineThrough
+                                } else {
+                                    TextDecoration.None
+                                },
+                            color =
+                                if (task.isCompleted) {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface
+                                },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
+                        )
+                        PriorityBadge(priority = task.priority)
+                    }
+                    TaskMetadataRow(task = task)
+                }
             }
             IconButton(onClick = onEditClick) {
                 Icon(
@@ -304,6 +430,48 @@ internal fun TaskListItem(
         }
     }
 }
+
+@Composable
+private fun TaskMetadataRow(task: TaskUiModel) {
+    val hasDueDate = task.dueDateLabel != null
+    val hasCategory = task.category != null
+
+    if (!hasDueDate && !hasCategory) return
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(Spacing.small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (hasDueDate) {
+            Text(
+                text = task.dueDateLabel!!,
+                style = MaterialTheme.typography.bodySmall,
+                color =
+                    if (task.isOverdue) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+            )
+        }
+        if (hasCategory) {
+            Text(
+                text = task.category!!,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Returns true when any filter is actively applied (search, priority, or category).
+ */
+private fun hasActiveFilters(
+    searchQuery: String,
+    filterPriority: Priority?,
+    filterCategory: String?,
+): Boolean = searchQuery.isNotEmpty() || filterPriority != null || filterCategory != null
 
 @Composable
 private fun EmptyTaskListContent(modifier: Modifier = Modifier) {

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListScreenPreview.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListScreenPreview.kt
@@ -3,6 +3,8 @@ package com.nshaddox.randomtask.ui.screens.tasklist
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.nshaddox.randomtask.domain.model.Priority
+import com.nshaddox.randomtask.domain.model.SortOrder
 import com.nshaddox.randomtask.ui.preview.SampleData
 import com.nshaddox.randomtask.ui.theme.RandomTaskTheme
 
@@ -14,7 +16,8 @@ import com.nshaddox.randomtask.ui.theme.RandomTaskTheme
 fun TaskListScreenPreview() {
     RandomTaskTheme {
         TaskListScreen(
-            tasks = SampleData.sampleTasks,
+            tasks = SampleData.sampleTaskUiModels,
+            availableCategories = listOf("Work", "Personal"),
         )
     }
 }
@@ -27,7 +30,7 @@ fun TaskListScreenPreview() {
 fun TaskListScreenEmptyPreview() {
     RandomTaskTheme {
         TaskListScreen(
-            tasks = SampleData.emptyTaskList,
+            tasks = emptyList(),
         )
     }
 }
@@ -40,7 +43,7 @@ fun TaskListScreenEmptyPreview() {
 fun TaskListScreenSingleTaskPreview() {
     RandomTaskTheme {
         TaskListScreen(
-            tasks = listOf(SampleData.singleTask),
+            tasks = listOf(SampleData.sampleTaskUiModel),
         )
     }
 }
@@ -67,22 +70,25 @@ fun TaskListScreenLoadingPreview() {
 fun TaskListScreenErrorPreview() {
     RandomTaskTheme {
         TaskListScreen(
-            tasks = SampleData.sampleTasks,
+            tasks = SampleData.sampleTaskUiModels,
             errorMessage = "Failed to load tasks",
         )
     }
 }
 
 /**
- * Preview for AddTaskDialog
+ * Preview for TaskListScreen with active filters
  */
 @Preview(showBackground = true)
 @Composable
-fun AddTaskDialogPreview() {
+fun TaskListScreenWithFiltersPreview() {
     RandomTaskTheme {
-        AddTaskDialog(
-            onConfirm = { _, _ -> },
-            onDismiss = {},
+        TaskListScreen(
+            tasks = SampleData.sampleTaskUiModels,
+            searchQuery = "project",
+            filterPriority = Priority.HIGH,
+            sortOrder = SortOrder.PRIORITY_DESC,
+            availableCategories = listOf("Work", "Personal"),
         )
     }
 }
@@ -95,7 +101,7 @@ fun AddTaskDialogPreview() {
 fun TaskListItemPreview() {
     RandomTaskTheme {
         TaskListItem(
-            task = SampleData.sampleTask,
+            task = SampleData.sampleTaskUiModel,
             onTaskClick = {},
             onCheckedChange = {},
             onEditClick = {},
@@ -112,7 +118,7 @@ fun TaskListItemPreview() {
 fun TaskListItemCompletedPreview() {
     RandomTaskTheme {
         TaskListItem(
-            task = SampleData.sampleTasks.first { it.isCompleted },
+            task = SampleData.sampleTaskUiModels.first { it.isCompleted },
             onTaskClick = {},
             onCheckedChange = {},
             onEditClick = {},
@@ -122,14 +128,32 @@ fun TaskListItemCompletedPreview() {
 }
 
 /**
- * Preview for AddTaskDialog with description field
+ * Preview for TaskListItem with overdue task
  */
 @Preview(showBackground = true)
 @Composable
-fun AddTaskDialogWithDescriptionPreview() {
+fun TaskListItemOverduePreview() {
     RandomTaskTheme {
-        AddTaskDialog(
-            onConfirm = { _, _ -> },
+        TaskListItem(
+            task = SampleData.sampleOverdueTaskUiModel,
+            onTaskClick = {},
+            onCheckedChange = {},
+            onEditClick = {},
+            onDeleteClick = {},
+        )
+    }
+}
+
+/**
+ * Preview for EditTaskDialog in add mode
+ */
+@Preview(showBackground = true)
+@Composable
+fun AddTaskDialogPreview() {
+    RandomTaskTheme {
+        EditTaskDialog(
+            task = null,
+            onConfirm = { _, _, _, _, _ -> },
             onDismiss = {},
         )
     }

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiState.kt
@@ -11,6 +11,8 @@ import com.nshaddox.randomtask.domain.model.Task
  * @property isLoading Whether a loading operation is in progress.
  * @property errorMessage An optional error message to display. Null when there is no error.
  * @property isAddDialogVisible Whether the add-task dialog is currently visible.
+ * @property isEditDialogVisible Whether the edit-task dialog is currently visible.
+ * @property editingTask The task currently being edited. Null when not editing.
  * @property searchQuery The current text entered in the search field. Empty string when inactive.
  * @property filterPriority The priority filter currently applied. Null when no priority filter is active.
  * @property filterCategory The category filter currently applied. Null when no category filter is active.
@@ -23,6 +25,8 @@ data class TaskListUiState(
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
     val isAddDialogVisible: Boolean = false,
+    val isEditDialogVisible: Boolean = false,
+    val editingTask: TaskUiModel? = null,
     val searchQuery: String = "",
     val filterPriority: Priority? = null,
     val filterCategory: String? = null,

--- a/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
+++ b/app/src/main/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModel.kt
@@ -196,6 +196,63 @@ class TaskListViewModel
             _uiState.update { it.copy(isAddDialogVisible = false) }
         }
 
+        fun showEditDialog(task: TaskUiModel) {
+            _uiState.update { it.copy(isEditDialogVisible = true, editingTask = task) }
+        }
+
+        fun hideEditDialog() {
+            _uiState.update { it.copy(isEditDialogVisible = false, editingTask = null) }
+        }
+
+        @Suppress("LongParameterList")
+        fun editTask(
+            taskId: Long,
+            title: String,
+            description: String? = null,
+            priority: Priority = Priority.MEDIUM,
+            dueDate: Long? = null,
+            category: String? = null,
+        ) {
+            viewModelScope.launch(ioDispatcher) {
+                // Fetch current task state from repository to preserve createdAt/updatedAt
+                val currentTasks = getTasksUseCase().first()
+                val existingTask = currentTasks.find { it.id == taskId }
+                if (existingTask == null) {
+                    _uiState.update {
+                        it.copy(
+                            errorMessage = "Task not found",
+                            isEditDialogVisible = false,
+                            editingTask = null,
+                        )
+                    }
+                    return@launch
+                }
+                val updated =
+                    existingTask.copy(
+                        title = title,
+                        description = description,
+                        priority = priority,
+                        dueDate = dueDate,
+                        category = category,
+                    )
+                updateTaskUseCase(updated)
+                    .onSuccess {
+                        _uiState.update {
+                            it.copy(isEditDialogVisible = false, editingTask = null)
+                        }
+                    }
+                    .onFailure { error ->
+                        _uiState.update {
+                            it.copy(
+                                errorMessage = error.message ?: "Failed to update task",
+                                isEditDialogVisible = false,
+                                editingTask = null,
+                            )
+                        }
+                    }
+            }
+        }
+
         fun clearError() {
             _uiState.update { it.copy(errorMessage = null) }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,21 @@
     <string name="edit_task_dialog_priority_medium">Medium</string>
     <string name="edit_task_dialog_priority_high">High</string>
 
+    <string name="edit_task_dialog_placeholder_category">Category (optional)</string>
+    <string name="edit_task_dialog_field_category">Category</string>
+
+    <!-- TaskFilterBar -->
+    <string name="filter_bar_search_hint">Search tasks</string>
+    <string name="filter_bar_clear_search">Clear search</string>
+    <string name="filter_bar_priority_all">All</string>
+    <string name="filter_bar_category_all">All Categories</string>
+    <string name="filter_bar_sort_label">Sort</string>
+
+    <!-- TaskListItem -->
+    <string name="task_item_overdue">Overdue</string>
+    <string name="cd_task_due_date">Due: %1$s</string>
+    <string name="cd_task_category">Category: %1$s</string>
+
     <!-- DueDatePickerDialog -->
     <string name="due_date_picker_title">Select Due Date</string>
     <string name="due_date_picker_confirm">Confirm</string>

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListUiStateTest.kt
@@ -193,4 +193,49 @@ class TaskListUiStateTest {
         assertTrue(str.contains("searchQuery=groceries"))
         assertTrue(str.contains("sortOrder=PRIORITY_DESC"))
     }
+
+    // ── Edit dialog state tests ──
+
+    @Test
+    fun `default state has edit dialog hidden`() {
+        val state = TaskListUiState()
+        assertFalse(state.isEditDialogVisible)
+    }
+
+    @Test
+    fun `default state has null editingTask`() {
+        val state = TaskListUiState()
+        assertNull(state.editingTask)
+    }
+
+    @Test
+    fun `copy with isEditDialogVisible true`() {
+        val state = TaskListUiState()
+        val withDialog = state.copy(isEditDialogVisible = true)
+        assertTrue(withDialog.isEditDialogVisible)
+    }
+
+    @Test
+    fun `copy with editingTask`() {
+        val uiModel =
+            TaskUiModel(
+                id = 1L,
+                title = "Test",
+                description = null,
+                isCompleted = false,
+                createdAt = "Jan 1, 2025",
+                updatedAt = "Jan 1, 2025",
+            )
+        val state = TaskListUiState()
+        val withTask = state.copy(editingTask = uiModel)
+        assertEquals(uiModel, withTask.editingTask)
+    }
+
+    @Test
+    fun `copy preserves edit dialog defaults when not overridden`() {
+        val state = TaskListUiState()
+        val copied = state.copy(isLoading = false)
+        assertFalse(copied.isEditDialogVisible)
+        assertNull(copied.editingTask)
+    }
 }

--- a/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModelTest.kt
+++ b/app/src/test/java/com/nshaddox/randomtask/ui/screens/tasklist/TaskListViewModelTest.kt
@@ -822,6 +822,208 @@ class TaskListViewModelTest {
             }
         }
 
+    // === Edit dialog tests ===
+
+    @Test
+    fun `showEditDialog sets isEditDialogVisible true and editingTask`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                val initial = awaitItem()
+                assertFalse(initial.isEditDialogVisible)
+                assertNull(initial.editingTask)
+
+                val uiModel =
+                    TaskUiModel(
+                        id = 1L,
+                        title = "Test",
+                        description = null,
+                        isCompleted = false,
+                        createdAt = "Jan 1, 2025",
+                        updatedAt = "Jan 1, 2025",
+                    )
+                viewModel.showEditDialog(uiModel)
+
+                val withDialog = awaitItem()
+                assertTrue(withDialog.isEditDialogVisible)
+                assertEquals(uiModel, withDialog.editingTask)
+            }
+        }
+
+    @Test
+    fun `hideEditDialog sets isEditDialogVisible false and clears editingTask`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+            val uiModel =
+                TaskUiModel(
+                    id = 1L,
+                    title = "Test",
+                    description = null,
+                    isCompleted = false,
+                    createdAt = "Jan 1, 2025",
+                    updatedAt = "Jan 1, 2025",
+                )
+            viewModel.showEditDialog(uiModel)
+
+            viewModel.uiState.test {
+                val withDialog = awaitItem()
+                assertTrue(withDialog.isEditDialogVisible)
+
+                viewModel.hideEditDialog()
+
+                val hidden = awaitItem()
+                assertFalse(hidden.isEditDialogVisible)
+                assertNull(hidden.editingTask)
+            }
+        }
+
+    @Test
+    fun `editTask updates existing task via repository`() =
+        runTest(testDispatcher) {
+            repository.addTask(createTask(title = "Original"))
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded with task
+                val loaded = awaitItem()
+                assertEquals(1, loaded.tasks.size)
+                val existingTask = loaded.tasks[0]
+
+                viewModel.editTask(
+                    taskId = existingTask.id,
+                    title = "Updated",
+                    description = "New description",
+                    priority = Priority.HIGH,
+                    dueDate = 500L,
+                    category = "Work",
+                )
+                advanceUntilIdle()
+
+                // Consume items until we see the updated task
+                var state = awaitItem()
+                // May need to skip dialog-hide emission
+                if (state.tasks.isNotEmpty() && state.tasks[0].title != "Updated") {
+                    state = awaitItem()
+                }
+                assertEquals(1, state.tasks.size)
+                assertEquals("Updated", state.tasks[0].title)
+                assertEquals("New description", state.tasks[0].description)
+                assertEquals(Priority.HIGH, state.tasks[0].priority)
+                assertEquals(500L, state.tasks[0].dueDate)
+                assertEquals("Work", state.tasks[0].category)
+                assertFalse(state.isEditDialogVisible)
+            }
+        }
+
+    @Test
+    fun `editTask with nonexistent taskId sets error and hides dialog`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded empty
+                awaitItem()
+
+                viewModel.editTask(
+                    taskId = 999L,
+                    title = "Should fail",
+                )
+                advanceUntilIdle()
+
+                val errorState = awaitItem()
+                assertEquals("Task not found", errorState.errorMessage)
+                assertFalse(errorState.isEditDialogVisible)
+                assertNull(errorState.editingTask)
+            }
+        }
+
+    @Test
+    fun `editTask hides edit dialog on success`() =
+        runTest(testDispatcher) {
+            repository.addTask(createTask(title = "Original"))
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded with task
+                val loaded = awaitItem()
+                val existingTask = loaded.tasks[0]
+
+                // Show the edit dialog first
+                val uiModel =
+                    TaskUiModel(
+                        id = existingTask.id,
+                        title = existingTask.title,
+                        description = null,
+                        isCompleted = false,
+                        createdAt = "Jan 1, 2025",
+                        updatedAt = "Jan 1, 2025",
+                    )
+                viewModel.showEditDialog(uiModel)
+                val withDialog = awaitItem()
+                assertTrue(withDialog.isEditDialogVisible)
+
+                viewModel.editTask(
+                    taskId = existingTask.id,
+                    title = "Updated Title",
+                )
+                advanceUntilIdle()
+
+                // Consume items until we see the dialog hidden and task updated.
+                // Multiple emissions may occur: dialog-hide and task-update.
+                var state = awaitItem()
+                while (state.isEditDialogVisible || state.tasks.any { it.title != "Updated Title" }) {
+                    state = awaitItem()
+                }
+                assertFalse(state.isEditDialogVisible)
+                assertNull(state.editingTask)
+                assertEquals("Updated Title", state.tasks[0].title)
+            }
+        }
+
+    @Test
+    fun `editTask with default parameters keeps medium priority and null dueDate`() =
+        runTest(testDispatcher) {
+            repository.addTask(
+                createTask(
+                    title = "Original",
+                    priority = Priority.HIGH,
+                    dueDate = 100L,
+                    category = "Work",
+                ),
+            )
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // Initial loading
+                awaitItem()
+                // Loaded with task
+                val loaded = awaitItem()
+                val existingTask = loaded.tasks[0]
+
+                viewModel.editTask(
+                    taskId = existingTask.id,
+                    title = "Updated",
+                )
+                advanceUntilIdle()
+
+                var state = awaitItem()
+                if (state.tasks.isNotEmpty() && state.tasks[0].title != "Updated") {
+                    state = awaitItem()
+                }
+                assertEquals("Updated", state.tasks[0].title)
+                assertEquals(Priority.MEDIUM, state.tasks[0].priority)
+                assertNull(state.tasks[0].dueDate)
+                assertNull(state.tasks[0].category)
+            }
+        }
+
     @Test
     fun `setSortOrder persists new sort order so next VM init restores it`() =
         runTest(testDispatcher) {


### PR DESCRIPTION
## Summary

- Implements `TaskFilterBar` composable with search, priority filter chips, category dropdown, and sort order selector
- Overhauls `TaskListScreen` to display v2 task fields (priority badges, due dates, categories) in task items
- Integrates `EditTaskDialog` for both add and edit flows, replacing the simple `AddTaskDialog`
- Adds edit dialog state management to `TaskListViewModel` (showEditDialog, hideEditDialog, editTask)
- 11 new unit tests covering edit flow and state transitions

## RPI Metrics

| Metric | Value |
|--------|-------|
| Tasks Planned | 7 |
| Tasks Completed | 7 |
| New Tests | 11 (5 UiState + 6 ViewModel) |

## Key Changes

- `ui/screens/tasklist/TaskFilterBar.kt` — New search/filter/sort composable
- `ui/screens/tasklist/TaskListScreen.kt` — Major overhaul: TaskUiModel, filter bar, edit dialog, metadata display
- `ui/screens/tasklist/TaskListViewModel.kt` — Edit flow: showEditDialog(), hideEditDialog(), editTask()
- `ui/screens/tasklist/TaskListUiState.kt` — Added isEditDialogVisible, editingTask fields
- `ui/screens/tasklist/EditTaskDialog.kt` — Added category field support

## Test Plan

- [x] All 36 ViewModel tests pass
- [x] All 24 UiState tests pass
- [x] Lint passes
- [x] No hardcoded strings

Closes #220, closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>