### PR TITLE
docs: add RPI recap summaries for v2 groups 7-10 features

### DIFF
--- a/docs/rpi/09-task-edit-components.md
+++ b/docs/rpi/09-task-edit-components.md
@@ -1,0 +1,37 @@
+# Task Edit Components
+
+**Feature**: 09-task-edit-components
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#219, GH#221
+
+## What Changed
+
+- Created `EditTaskDialog` dual-mode composable (add/edit) with title, description, priority selector, due date picker, and category fields
+- Created `DueDatePickerDialog` wrapping Material3 DatePicker with clear/confirm/cancel actions
+- Enabled core library desugaring for `java.time.LocalDate` API support on API 24+
+- Added 17 string resources and 14 instrumented Compose UI tests
+
+## Why
+
+v2.0 requires full-featured task editing with priority, due dates, and categories. The simple `AddTaskDialog` (title + description only) needed replacement.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/screens/tasklist/EditTaskDialog.kt` | Created |
+| `ui/components/DueDatePickerDialog.kt` | Created |
+| `app/build.gradle.kts` | Modified (desugaring) |
+| `res/values/strings.xml` | Modified |
+
+## Implementation Notes
+
+- `EditTaskDialog` accepts `TaskUiModel?` — null for add mode, non-null for edit mode
+- `DueDatePickerDialog` placed in `ui.components` for cross-screen reuse
+- Added `initialDueDate: LocalDate?` parameter beyond plan spec since `TaskUiModel` has no raw date field
+
+## Verification
+
+- [x] 14 instrumented tests (6 DueDatePicker + 8 EditTaskDialog)
+- [x] Lint + unit tests pass

--- a/docs/rpi/10-completedtasks-feature.md
+++ b/docs/rpi/10-completedtasks-feature.md
@@ -1,0 +1,37 @@
+# CompletedTasks Feature
+
+**Feature**: 10-completedtasks-feature
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#218, GH#223, GH#225
+
+## What Changed
+
+- Created `PriorityBadge` reusable composable with color-coded badges (green/amber/red) per priority level
+- Created `CompletedTasksScreen` with SwipeToDismissBox, empty state, and completed timestamp display
+- Wired CompletedTasks route into NavGraph and added history icon to TaskListScreen TopAppBar
+- Added 19 unit tests (9 PriorityBadge + 10 screen state/date formatting)
+
+## Why
+
+Users need to view their task completion history and see priority levels at a glance across screens.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/components/PriorityBadge.kt` | Created |
+| `ui/screens/completedtasks/CompletedTasksScreen.kt` | Created |
+| `ui/navigation/NavGraph.kt` | Modified |
+| `ui/screens/tasklist/TaskListScreen.kt` | Modified |
+
+## Implementation Notes
+
+- Extracted `resolveContentState()` pure function for testable state logic
+- `formatCompletedDate()` accepts explicit `Locale` parameter for CI stability
+- SwipeToDismissBox uses `@OptIn(ExperimentalMaterial3Api::class)`
+
+## Verification
+
+- [x] 19 unit tests pass
+- [x] Lint clean, no hardcoded strings

--- a/docs/rpi/11-tasklist-screen-update.md
+++ b/docs/rpi/11-tasklist-screen-update.md
@@ -1,0 +1,38 @@
+# TaskListScreen Update
+
+**Feature**: 11-tasklist-screen-update
+**Date**: 2026-03-14
+**Complexity**: High
+**Source Issues**: GH#220, GH#222
+
+## What Changed
+
+- Created `TaskFilterBar` composable with search field, priority filter chips, category dropdown, sort order selector
+- Overhauled `TaskListScreen` to display v2 task fields (priority badges, due dates, categories) in task items
+- Integrated `EditTaskDialog` for both add and edit flows, replacing `AddTaskDialog`
+- Added edit dialog state management to `TaskListViewModel` (showEditDialog, hideEditDialog, editTask)
+- 11 new unit tests covering edit flow and state transitions
+
+## Why
+
+The main task list needed to expose all v2.0 features: search/filter/sort controls and full task metadata display.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/screens/tasklist/TaskFilterBar.kt` | Created |
+| `ui/screens/tasklist/TaskListScreen.kt` | Modified (major) |
+| `ui/screens/tasklist/TaskListViewModel.kt` | Modified |
+| `ui/screens/tasklist/TaskListUiState.kt` | Modified |
+
+## Implementation Notes
+
+- TaskListScreen now works with `TaskUiModel` instead of raw `Task` for display
+- Edit dialog state (isEditDialogVisible, editingTask) added to UiState
+- `AddTaskDialog` still exists but is no longer used from the ViewModel wrapper
+
+## Verification
+
+- [x] 36 ViewModel tests, 24 UiState tests pass
+- [x] Lint clean

--- a/docs/rpi/12-settings-feature.md
+++ b/docs/rpi/12-settings-feature.md
@@ -1,0 +1,37 @@
+# Settings Feature
+
+**Feature**: 12-settings-feature
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#224, GH#226, GH#230
+
+## What Changed
+
+- Created `SettingsScreen` with theme selection (Light/Dark/System) and default sort order radio groups
+- Wired Settings route into NavGraph and added Settings icon to TaskListScreen TopAppBar
+- Applied theme preference to `MaterialTheme` in `MainActivity` via extracted `resolveTheme()` function
+- Enabled `buildConfig` for `BuildConfig.VERSION_NAME` in About section
+
+## Why
+
+Users need a settings screen to control app theme and default sort behavior, persisted across restarts.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/screens/settings/SettingsScreen.kt` | Created |
+| `ThemeResolution.kt` | Created |
+| `MainActivity.kt` | Modified |
+| `ui/navigation/NavGraph.kt` | Modified |
+| `app/build.gradle.kts` | Modified |
+
+## Implementation Notes
+
+- `resolveTheme()` is a pure function for testable theme logic (no Compose dependency)
+- SettingsViewModel was pre-existing; only the screen composable was new
+
+## Verification
+
+- [x] 4 theme resolution tests (all AppTheme branches)
+- [x] Lint clean, no hardcoded strings

--- a/docs/rpi/13-sort-tasks.md
+++ b/docs/rpi/13-sort-tasks.md
@@ -1,0 +1,33 @@
+# Sort Tasks Persistence
+
+**Feature**: 13-sort-tasks
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#229
+
+## What Changed
+
+- Bridged the DataStore persistence gap in `TaskListViewModel`: reads persisted sort order on init, writes back on change
+- Added 2 new persistence round-trip tests
+
+## Why
+
+Sort logic was already implemented but the chosen sort order was lost on app restart — it always reset to "Newest First".
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/screens/tasklist/TaskListViewModel.kt` | Modified |
+| `ui/screens/tasklist/TaskListViewModelTest.kt` | Modified |
+
+## Implementation Notes
+
+- Injected `DataStore<Preferences>` as 10th constructor parameter
+- Uses same `SORT_ORDER_KEY` as `SettingsViewModel` (both read/write "sort_order" preference)
+- DRY concern: key defined as private companion in both VMs
+
+## Verification
+
+- [x] 30 tests pass (28 existing + 2 new persistence tests)
+- [x] Lint clean

--- a/docs/rpi/14-weighted-random.md
+++ b/docs/rpi/14-weighted-random.md
@@ -1,0 +1,35 @@
+# Weighted Random Task Selection
+
+**Feature**: 14-weighted-random
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#231
+
+## What Changed
+
+- Created `GetWeightedRandomTaskUseCase` with priority weighting (HIGH 3x, MEDIUM 2x, LOW 1x)
+- Added toggle in `RandomTaskViewModel` to switch between uniform and weighted random selection
+- Added "Prioritise high-priority tasks" Switch toggle in `RandomTaskScreen`
+
+## Why
+
+Users wanted the option to bias random task selection toward higher-priority tasks.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `domain/usecase/GetWeightedRandomTaskUseCase.kt` | Created |
+| `ui/screens/randomtask/RandomTaskViewModel.kt` | Modified |
+| `ui/screens/randomtask/RandomTaskScreen.kt` | Modified |
+
+## Implementation Notes
+
+- Use case is pure Kotlin (zero Android imports) — mirrors `GetRandomTaskUseCase` structure
+- `buildWeightedPool` is `internal` (not private) to enable deterministic pool-structure tests
+- Toggle is a separate `StateFlow<Boolean>` — `RandomTaskUiState` unchanged
+
+## Verification
+
+- [x] 6 use case tests + 5 ViewModel toggle tests
+- [x] `GetRandomTaskUseCase` byte-for-byte unchanged

--- a/docs/rpi/15-delete-ux.md
+++ b/docs/rpi/15-delete-ux.md
@@ -1,0 +1,37 @@
+# Delete UX (Swipe + Undo)
+
+**Feature**: 15-delete-ux
+**Date**: 2026-03-14
+**Complexity**: Medium
+**Source Issues**: GH#227, GH#228
+
+## What Changed
+
+- Added SwipeToDismissBox swipe-to-delete gesture on task items in both TaskListScreen and CompletedTasksScreen
+- Implemented undo snackbar: "Task deleted" with "Undo" action that restores the deleted task
+- Only one pending undo at a time — new deletion replaces previous
+- Undo for completed tasks re-creates and re-marks as completed
+
+## Why
+
+Accidental deletions needed a safety net. Swipe-to-delete is the expected mobile UX pattern.
+
+## Key Files
+
+| File | Change Type |
+|------|-------------|
+| `ui/screens/tasklist/TaskListViewModel.kt` | Modified |
+| `ui/screens/tasklist/TaskListScreen.kt` | Modified |
+| `ui/screens/completedtasks/CompletedTasksViewModel.kt` | Modified |
+| `ui/screens/completedtasks/CompletedTasksScreen.kt` | Modified |
+
+## Implementation Notes
+
+- Undo re-creates task via `AddTaskUseCase` (new ID + timestamps) — acceptable tradeoff
+- `pendingDeleteTask` field added to both UiState classes
+- CompletedTasks undo also injects `CompleteTaskUseCase` to re-mark restored tasks
+
+## Verification
+
+- [x] 16 new tests (7 TaskList VM + 8 CompletedTasks VM + 6 UiState)
+- [x] All quality gates pass


### PR DESCRIPTION
## Summary

Adds permanent RPI recap documentation for all 7 features implemented in the groups 7-10 run:
- 09-task-edit-components (GH#219, GH#221)
- 10-completedtasks-feature (GH#218, GH#223, GH#225)
- 11-tasklist-screen-update (GH#220, GH#222)
- 12-settings-feature (GH#224, GH#226, GH#230)
- 13-sort-tasks (GH#229)
- 14-weighted-random (GH#231)
- 15-delete-ux (GH#227, GH#228)

🤖 Generated with [Claude Code](https://claude.com/claude-code)